### PR TITLE
Add Mint installation instructions

### DIFF
--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -2,7 +2,7 @@
 
 ## CLI
 
-### Building from sources
+### Building from source
 
 1. Clone the repository
 ```sh
@@ -27,7 +27,23 @@ export PATH="$PATH:$(swift -c release --show-bin-path)"
 
 ### Mint
 
-*TODO*
+To run xcdiff using [Mint](https://github.com/yonaskolb/Mint):
+
+```sh
+mint run bloomberg/xcdiff xcdiff --help
+```
+
+To install xcdiff using [Mint](https://github.com/yonaskolb/Mint):
+
+```sh
+mint install bloomberg/xcdiff
+```
+
+Once installed, you can use xcdiff directly:
+
+```sh
+xcdiff --help
+```
 
 ## Framework
 


### PR DESCRIPTION
**Describe your changes**
Updating documentation with instructions on how to install xcdiff using Mint.

**Testing performed**
Run and verify the following commands work:

- `mint run bloomberg/xcdiff xcdiff --help`
- `mint install bloomberg/xcdiff`