### PR TITLE
Make command line target filter option behavior consistent

### DIFF
--- a/CommandTests/Manual/p1_p2_g_headers_target_only_in_second.md
+++ b/CommandTests/Manual/p1_p2_g_headers_target_only_in_second.md
@@ -1,0 +1,13 @@
+# Command
+```json
+["-p1", "{ios_project_1}", "-p2", "{ios_project_2}", "-g", "headers", "-t", "NewFramework", "-v"]
+```
+
+# Expected exit code
+1
+
+# Expected output
+```
+ERROR: Cannot find target "NewFramework"
+
+```

--- a/CommandTests/Manual/p1_p2_g_targets_target_only_in_second.md
+++ b/CommandTests/Manual/p1_p2_g_targets_target_only_in_second.md
@@ -1,0 +1,21 @@
+# Command
+```json
+["-p1", "{ios_project_1}", "-p2", "{ios_project_2}", "-g", "targets", "-t", "NewFramework", "-v"]
+```
+
+# Expected exit code
+2
+
+# Expected output
+```
+❌ TARGETS > NATIVE targets
+
+⚠️  Only in second (1):
+
+  • NewFramework
+
+
+✅ TARGETS > AGGREGATE targets
+
+
+```

--- a/CommandTests/Manual/p1_p2_no_common_targets.2.md
+++ b/CommandTests/Manual/p1_p2_no_common_targets.2.md
@@ -1,0 +1,13 @@
+# Command
+```json
+["-p1", "{ios_project_1}", "-p2", "{ios_project_2}", "-t", "NON_EXISTING"]
+```
+
+# Expected exit code
+1
+
+# Expected output
+```
+ERROR: Cannot find target "NON_EXISTING"
+
+```

--- a/Sources/XCDiffCore/Comparator/DependenciesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/DependenciesComparator.swift
@@ -28,8 +28,7 @@ final class DependenciesComparator: Comparator {
     func compare(_ first: ProjectDescriptor,
                  _ second: ProjectDescriptor,
                  parameters: ComparatorParameters) throws -> [CompareResult] {
-        let commonTargets = try targetsHelper.commonTargets(first, second).filter(by: parameters.targets)
-
+        let commonTargets = try targetsHelper.commonTargets(first, second, parameters: parameters)
         let results = try commonTargets.flatMap { commonTarget in
             [try createLinkedDependenciesResults(commonTarget: commonTarget),
              try createEmbeddedFrameworksResults(commonTarget: commonTarget)]

--- a/Sources/XCDiffCore/Comparator/HeadersComparator.swift
+++ b/Sources/XCDiffCore/Comparator/HeadersComparator.swift
@@ -25,10 +25,7 @@ final class HeadersComparator: Comparator {
     func compare(_ first: ProjectDescriptor,
                  _ second: ProjectDescriptor,
                  parameters: ComparatorParameters) throws -> [CompareResult] {
-        let commonTargets = try targetsHelper
-            .commonTargets(first, second)
-            .filter(by: parameters.targets)
-
+        let commonTargets = try targetsHelper.commonTargets(first, second, parameters: parameters)
         return try commonTargets.map { firstTarget, secondTarget -> CompareResult in
             let firstHeaders = try targetsHelper.headers(from: firstTarget, sourceRoot: first.sourceRoot)
             let secondHeaders = try targetsHelper.headers(from: secondTarget, sourceRoot: second.sourceRoot)

--- a/Sources/XCDiffCore/Comparator/ResolvedSettingsComparator.swift
+++ b/Sources/XCDiffCore/Comparator/ResolvedSettingsComparator.swift
@@ -34,9 +34,7 @@ final class ResolvedSettingsComparator: Comparator {
     func compare(_ first: ProjectDescriptor,
                  _ second: ProjectDescriptor,
                  parameters: ComparatorParameters) throws -> [CompareResult] {
-        let commonTargets = try targetHelper
-            .commonTargets(first, second)
-            .filter(by: parameters.targets)
+        let commonTargets = try targetHelper.commonTargets(first, second, parameters: parameters)
         let commonConfigurations = targetHelper
             .commonConfigurations(first, second)
             .filter(by: parameters.configurations)

--- a/Sources/XCDiffCore/Comparator/ResourcesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/ResourcesComparator.swift
@@ -17,19 +17,16 @@
 import Foundation
 
 final class ResourcesComparator: Comparator {
-    var tag = "resources"
-    private let helper = TargetsHelper()
+    let tag = "resources"
+    private let targetsHelper = TargetsHelper()
 
     func compare(_ first: ProjectDescriptor,
                  _ second: ProjectDescriptor,
                  parameters: ComparatorParameters) throws -> [CompareResult] {
-        let commonTargets = try helper
-            .commonTargets(first, second)
-            .filter(by: parameters.targets)
-
+        let commonTargets = try targetsHelper.commonTargets(first, second, parameters: parameters)
         let compareResults = try commonTargets.map { firstTarget, secondTarget -> CompareResult in
-            let firstPaths = Set(try helper.resources(from: firstTarget, sourceRoot: first.sourceRoot))
-            let secondPaths = Set(try helper.resources(from: secondTarget, sourceRoot: second.sourceRoot))
+            let firstPaths = Set(try targetsHelper.resources(from: firstTarget, sourceRoot: first.sourceRoot))
+            let secondPaths = Set(try targetsHelper.resources(from: secondTarget, sourceRoot: second.sourceRoot))
 
             return result(context: ["\"\(firstTarget.name)\" target"],
                           first: firstPaths,

--- a/Sources/XCDiffCore/Comparator/SettingsComparator.swift
+++ b/Sources/XCDiffCore/Comparator/SettingsComparator.swift
@@ -44,9 +44,7 @@ final class SettingsComparator: Comparator {
     private func createTargetRawSettingsResult(_ first: ProjectDescriptor,
                                                _ second: ProjectDescriptor,
                                                parameters: ComparatorParameters) throws -> [CompareResult] {
-        let commonTargets = try targetHelper
-            .commonTargets(first, second)
-            .filter(by: parameters.targets)
+        let commonTargets = try targetHelper.commonTargets(first, second, parameters: parameters)
         let commonConfigurations = targetHelper
             .commonConfigurations(first, second)
             .filter(by: parameters.configurations)

--- a/Sources/XCDiffCore/Comparator/SourcesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/SourcesComparator.swift
@@ -19,20 +19,17 @@ import Foundation
 final class SourcesComparator: Comparator {
     private typealias SourcePair = (first: SourceDescriptor, second: SourceDescriptor)
 
-    var tag = "sources"
-    private let helper = TargetsHelper()
+    let tag = "sources"
+    private let targetsHelper = TargetsHelper()
 
     func compare(_ first: ProjectDescriptor,
                  _ second: ProjectDescriptor,
                  parameters: ComparatorParameters) throws -> [CompareResult] {
-        let commonTargets = try helper
-            .commonTargets(first, second)
-            .filter(by: parameters.targets)
-
-        let sourcesResults = try commonTargets
+        let commonTargets = try targetsHelper.commonTargets(first, second, parameters: parameters)
+        return try commonTargets
             .map { firstTarget, secondTarget -> CompareResult in
-                let firstSources = try helper.sources(from: firstTarget, sourceRoot: first.sourceRoot)
-                let secondSources = try helper.sources(from: secondTarget, sourceRoot: second.sourceRoot)
+                let firstSources = try targetsHelper.sources(from: firstTarget, sourceRoot: first.sourceRoot)
+                let secondSources = try targetsHelper.sources(from: secondTarget, sourceRoot: second.sourceRoot)
 
                 let firstPaths = Set(firstSources.map { $0.path })
                 let secondPaths = Set(secondSources.map { $0.path })
@@ -45,7 +42,6 @@ final class SourcesComparator: Comparator {
                               second: secondPaths,
                               differentValues: difference)
             }
-        return sourcesResults
     }
 
     /// Returns common sources as a source pair

--- a/Sources/XCDiffCore/Comparator/TargetsComparator.swift
+++ b/Sources/XCDiffCore/Comparator/TargetsComparator.swift
@@ -19,16 +19,19 @@ import Foundation
 final class TargetsComparator: Comparator {
     let tag = "targets"
 
-    private let targets = TargetsHelper()
+    private let targetsHelper = TargetsHelper()
 
     func compare(_ first: ProjectDescriptor,
                  _ second: ProjectDescriptor,
                  parameters: ComparatorParameters) throws -> [CompareResult] {
+        try targetsHelper.targets(from: first)
+            .union(targetsHelper.targets(from: second))
+            .validateTargetsOption(parameters)
         return results(context: ["NATIVE targets"],
-                       first: targets.native(from: first).filter(by: parameters.targets),
-                       second: targets.native(from: second).filter(by: parameters.targets))
+                       first: targetsHelper.native(from: first).filter(by: parameters.targets),
+                       second: targetsHelper.native(from: second).filter(by: parameters.targets))
             + results(context: ["AGGREGATE targets"],
-                      first: targets.aggregate(from: first).filter(by: parameters.targets),
-                      second: targets.aggregate(from: second).filter(by: parameters.targets))
+                      first: targetsHelper.aggregate(from: first).filter(by: parameters.targets),
+                      second: targetsHelper.aggregate(from: second).filter(by: parameters.targets))
     }
 }

--- a/Tests/XCDiffCoreTests/Comparator/TargetsComparatorTests.swift
+++ b/Tests/XCDiffCoreTests/Comparator/TargetsComparatorTests.swift
@@ -122,4 +122,23 @@ final class TargetsComparatorTests: XCTestCase {
         ]
         XCTAssertEqual(actual, expected)
     }
+
+    func testCompare_whenFilterNonExistingTargetName() {
+        // Given
+        let first = project()
+            .addTargets(names: ["A", "B", "C"])
+            .addAggregateTargets(names: ["D", "E"])
+            .projectDescriptor()
+        let second = project()
+            .addTargets(names: ["A", "B", "C"])
+            .addAggregateTargets(names: ["D", "E"])
+            .projectDescriptor()
+        let parameters = ComparatorParameters(targets: .only("NOT_EXISTING"),
+                                              configurations: .all)
+
+        // When / Then
+        XCTAssertThrowsError(try sut.compare(first, second, parameters: parameters)) { error in
+            XCTAssertEqual(error.localizedDescription, "Cannot find target \"NOT_EXISTING\"")
+        }
+    }
 }


### PR DESCRIPTION
**Describe your changes**
Command line options `-t` (target) and `-c` (configuration) are treated inconsistently. Configuration comparator ignores completely non-existing configurations, same target comparator. Other comparators would trigger an error if non-existing target was specified but settings comparator ignores non-existing configuration. To make the API more consistent we want to unify the behavior.
- `-t` for `TargetsComparator` will trigger an error if target name is not present in any of the projects.
- `-t` for any other comparator will trigger an error if target name is not present in at least one of the projects.

