### PR TITLE
change error to include usage info

### DIFF
--- a/Sources/XCDiffCommand/CommandRunner.swift
+++ b/Sources/XCDiffCommand/CommandRunner.swift
@@ -211,7 +211,7 @@ public final class CommandRunner {
         // error, one of the paths is not defined, and cannot find 2 projects
         // in the current directory
         throw CommandError.generic("""
-        Could not find 2 projects in the current directory, 
+        Could not find 2 projects in the current directory,
         use `-p1` and `-p2` to specify the projects paths to compare
         """)
     }

--- a/Sources/XCDiffCommand/CommandRunner.swift
+++ b/Sources/XCDiffCommand/CommandRunner.swift
@@ -210,7 +210,10 @@ public final class CommandRunner {
 
         // error, one of the paths is not defined, and cannot find 2 projects
         // in the current directory
-        throw CommandError.generic("Could not find 2 projects in the current directory")
+        throw CommandError.generic("""
+        Could not find 2 projects in the current directory, 
+        use `-p1` and `-p2` to specify the projects paths to compare
+        """)
     }
 
     private func getFormat(from arguments: ArgumentParser.Result) throws -> XCDiffCore.Format {

--- a/Tests/XCDiffCommandTests/CommandsRunnerTests.swift
+++ b/Tests/XCDiffCommandTests/CommandsRunnerTests.swift
@@ -146,7 +146,10 @@ final class CommandsRunnerTests: XCTestCase {
         let code = subject.run(with: command)
 
         // Then
-        let expected = "ERROR: Could not find 2 projects in the current directory\n"
+        let expected = """
+        ERROR: Could not find 2 projects in the current directory, 
+        use `-p1` and `-p2` to specify the projects paths to compare\n
+        """
         XCTAssertEqual(printer.output, expected)
         XCTAssertEqual(code, 1)
     }

--- a/Tests/XCDiffCommandTests/CommandsRunnerTests.swift
+++ b/Tests/XCDiffCommandTests/CommandsRunnerTests.swift
@@ -147,7 +147,7 @@ final class CommandsRunnerTests: XCTestCase {
 
         // Then
         let expected = """
-        ERROR: Could not find 2 projects in the current directory, 
+        ERROR: Could not find 2 projects in the current directory,
         use `-p1` and `-p2` to specify the projects paths to compare\n
         """
         XCTAssertEqual(printer.output, expected)


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #5

Describe your changes
- Updates error message to message suggested in the issue description: "Could not find 2 projects in the current directory, use -p1 and -p2 to specify the projects paths to compare"

Testing performed
- Run in directory with no projects

Additional context
N/A