### PR TITLE
Update target comparator to compare product types

### DIFF
--- a/CommandTests/Generated/p1_p2.2.bac5a245.md
+++ b/CommandTests/Generated/p1_p2.2.bac5a245.md
@@ -11,14 +11,17 @@
 ❌ FILE_REFERENCES
 ❌ TARGETS > NATIVE targets
 ❌ TARGETS > AGGREGATE targets
+❌ HEADERS > "MismatchingLibrary" target
 ✅ HEADERS > "Project" target
 ❌ HEADERS > "ProjectFramework" target
 ✅ HEADERS > "ProjectTests" target
 ✅ HEADERS > "ProjectUITests" target
+✅ SOURCES > "MismatchingLibrary" target
 ❌ SOURCES > "Project" target
 ✅ SOURCES > "ProjectFramework" target
 ❌ SOURCES > "ProjectTests" target
 ❌ SOURCES > "ProjectUITests" target
+✅ RESOURCES > "MismatchingLibrary" target
 ❌ RESOURCES > "Project" target
 ✅ RESOURCES > "ProjectFramework" target
 ❌ RESOURCES > "ProjectTests" target
@@ -28,14 +31,18 @@
 ❌ SETTINGS > Root project > "Debug" configuration > Values
 ✅ SETTINGS > Root project > "Release" configuration > Base configuration
 ❌ SETTINGS > Root project > "Release" configuration > Values
+✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Values
+✅ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Values
 ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Debug" configuration > Values
 ✅ SETTINGS > "Project" target > "Release" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Release" configuration > Values
 ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
 ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Base configuration
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Values
 ✅ SETTINGS > "ProjectTests" target > "Release" configuration > Base configuration
@@ -45,6 +52,8 @@
 ✅ SETTINGS > "ProjectUITests" target > "Release" configuration > Base configuration
 ✅ SETTINGS > "ProjectUITests" target > "Release" configuration > Values
 ❌ SOURCE_TREES > Root project
+✅ DEPENDENCIES > "MismatchingLibrary" target > Linked Dependencies
+✅ DEPENDENCIES > "MismatchingLibrary" target > Embedded Frameworks
 ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 ✅ DEPENDENCIES > "ProjectFramework" target > Linked Dependencies

--- a/CommandTests/Generated/p1_p2_NewFramework_target.1.38b5ee4a.md
+++ b/CommandTests/Generated/p1_p2_NewFramework_target.1.38b5ee4a.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_NewFramework_target_console_format.1.c79021d5.md
+++ b/CommandTests/Generated/p1_p2_NewFramework_target_console_format.1.c79021d5.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_NewFramework_target_console_format_verbose.1.e602511d.md
+++ b/CommandTests/Generated/p1_p2_NewFramework_target_console_format_verbose.1.e602511d.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_NewFramework_target_json_format.1.6281eb3a.md
+++ b/CommandTests/Generated/p1_p2_NewFramework_target_json_format.1.6281eb3a.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_NewFramework_target_json_format_verbose.1.5934444b.md
+++ b/CommandTests/Generated/p1_p2_NewFramework_target_json_format_verbose.1.5934444b.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_NewFramework_target_markdown_format.1.2f8744c2.md
+++ b/CommandTests/Generated/p1_p2_NewFramework_target_markdown_format.1.2f8744c2.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_NewFramework_target_markdown_format_verbose.1.15ad4840.md
+++ b/CommandTests/Generated/p1_p2_NewFramework_target_markdown_format_verbose.1.15ad4840.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_NewFramework_target_verbose.1.41f31e6e.md
+++ b/CommandTests/Generated/p1_p2_NewFramework_target_verbose.1.41f31e6e.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_Project_target_console_format_verbose.2.ba4ce842.md
+++ b/CommandTests/Generated/p1_p2_Project_target_console_format_verbose.2.ba4ce842.md
@@ -10,7 +10,7 @@
 ```
 ❌ FILE_REFERENCES
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • Project/Group B/AViewController.xib
   • Project/Group B/AnotherObjcClass.h
@@ -19,10 +19,13 @@
   • ProjectTests/BarTests.swift
   • ProjectUITests/LoginTests.swift
   • ProjectUITests/Screenshots/empty.png
+  • libMismatchingLibrary.a
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
+  • MismatchingLibrary.framework
+  • MismatchingLibrary/MismatchingLibrary-Info.plist
   • NewFramework.framework
   • NewFramework/Info.plist
   • NewFramework/NewFramework.h
@@ -101,6 +104,11 @@
 
 ❌ SETTINGS > "Project" target > "Debug" configuration > Values
 
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
+
 ⚠️  Value mismatch (1):
 
   • CUSTOM_SETTING_COMMON
@@ -110,6 +118,11 @@
 
 ✅ SETTINGS > "Project" target > "Release" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Release" configuration > Values
+
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
 
 ⚠️  Value mismatch (1):
 
@@ -121,7 +134,7 @@
 ❌ SOURCE_TREES > Root project
 Output format: (<path>, <name>, <source_tree>)
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • (AViewController.xib, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
   • (AnotherObjcClass.h, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
@@ -129,15 +142,18 @@ Output format: (<path>, <name>, <source_tree>)
   • (BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
   • (empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
   • (Header4.h, nil, <group>) → (ProjectFramework, nil, <group>) → (nil, nil, <group>)
   • (Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
@@ -147,8 +163,9 @@ Output format: (<path>, <name>, <source_tree>)
 
 ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 
@@ -161,8 +178,9 @@ Output format: (<path>, <name>, <source_tree>)
 
 ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 

--- a/CommandTests/Generated/p1_p2_Project_target_json_format.2.1b44ee6e.md
+++ b/CommandTests/Generated/p1_p2_Project_target_json_format.2.1b44ee6e.md
@@ -23,9 +23,12 @@
       "Project\/Resources\/time.png",
       "ProjectTests\/BarTests.swift",
       "ProjectUITests\/LoginTests.swift",
-      "ProjectUITests\/Screenshots\/empty.png"
+      "ProjectUITests\/Screenshots\/empty.png",
+      "libMismatchingLibrary.a"
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
+      "MismatchingLibrary\/MismatchingLibrary-Info.plist",
       "NewFramework.framework",
       "NewFramework\/Info.plist",
       "NewFramework\/NewFramework.h",
@@ -243,7 +246,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   },
@@ -281,7 +284,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   },
@@ -300,6 +303,7 @@
       "(BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
       "(empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)"
     ],
     "onlyInSecond" : [
@@ -307,6 +311,8 @@
       "(Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)",
@@ -331,6 +337,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"
@@ -347,6 +354,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"

--- a/CommandTests/Generated/p1_p2_Project_target_json_format_verbose.2.bcad53ce.md
+++ b/CommandTests/Generated/p1_p2_Project_target_json_format_verbose.2.bcad53ce.md
@@ -23,9 +23,12 @@
       "Project\/Resources\/time.png",
       "ProjectTests\/BarTests.swift",
       "ProjectUITests\/LoginTests.swift",
-      "ProjectUITests\/Screenshots\/empty.png"
+      "ProjectUITests\/Screenshots\/empty.png",
+      "libMismatchingLibrary.a"
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
+      "MismatchingLibrary\/MismatchingLibrary-Info.plist",
       "NewFramework.framework",
       "NewFramework\/Info.plist",
       "NewFramework\/NewFramework.h",
@@ -243,7 +246,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   },
@@ -281,7 +284,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   },
@@ -300,6 +303,7 @@
       "(BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
       "(empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)"
     ],
     "onlyInSecond" : [
@@ -307,6 +311,8 @@
       "(Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)",
@@ -331,6 +337,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"
@@ -347,6 +354,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"

--- a/CommandTests/Generated/p1_p2_Project_target_markdown_format_verbose.2.f582a13e.md
+++ b/CommandTests/Generated/p1_p2_Project_target_markdown_format_verbose.2.f582a13e.md
@@ -12,7 +12,7 @@
 ## ❌ FILE_REFERENCES
 
 
-### ⚠️  Only in first (7):
+### ⚠️  Only in first (8):
 
   - `Project/Group B/AViewController.xib`
   - `Project/Group B/AnotherObjcClass.h`
@@ -21,10 +21,13 @@
   - `ProjectTests/BarTests.swift`
   - `ProjectUITests/LoginTests.swift`
   - `ProjectUITests/Screenshots/empty.png`
+  - `libMismatchingLibrary.a`
 
 
-### ⚠️  Only in second (9):
+### ⚠️  Only in second (11):
 
+  - `MismatchingLibrary.framework`
+  - `MismatchingLibrary/MismatchingLibrary-Info.plist`
   - `NewFramework.framework`
   - `NewFramework/Info.plist`
   - `NewFramework/NewFramework.h`
@@ -127,6 +130,11 @@
 ## ❌ SETTINGS > "Project" target > "Debug" configuration > Values
 
 
+### ⚠️  Only in second (1):
+
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
+
+
 ### ⚠️  Value mismatch (1):
 
   - `CUSTOM_SETTING_COMMON`
@@ -141,6 +149,11 @@
 ## ❌ SETTINGS > "Project" target > "Release" configuration > Values
 
 
+### ⚠️  Only in second (1):
+
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
+
+
 ### ⚠️  Value mismatch (1):
 
   - `CUSTOM_SETTING_COMMON`
@@ -153,7 +166,7 @@
 
 Output format: (<path>, <name>, <source_tree>)
 
-### ⚠️  Only in first (7):
+### ⚠️  Only in first (8):
 
   - `(AViewController.xib, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
   - `(AnotherObjcClass.h, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
@@ -161,15 +174,18 @@ Output format: (<path>, <name>, <source_tree>)
   - `(BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)`
   - `(LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)`
   - `(empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)`
+  - `(libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)`
   - `(time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
 
 
-### ⚠️  Only in second (9):
+### ⚠️  Only in second (11):
 
   - `(Header4.h, nil, <group>) → (ProjectFramework, nil, <group>) → (nil, nil, <group>)`
   - `(Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)`
   - `(ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)`
   - `(MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)`
+  - `(MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)`
+  - `(MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)`
   - `(NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)`
   - `(NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)`
   - `(Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
@@ -181,8 +197,9 @@ Output format: (<path>, <name>, <source_tree>)
 ## ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 
 
-### ⚠️  Only in second (1):
+### ⚠️  Only in second (2):
 
+  - `MismatchingLibrary.framework`
   - `NewFramework.framework`
 
 
@@ -197,8 +214,9 @@ Output format: (<path>, <name>, <source_tree>)
 ## ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 
 
-### ⚠️  Only in second (1):
+### ⚠️  Only in second (2):
 
+  - `MismatchingLibrary.framework`
   - `NewFramework.framework`
 
 

--- a/CommandTests/Generated/p1_p2_Project_target_verbose.2.6f518e43.md
+++ b/CommandTests/Generated/p1_p2_Project_target_verbose.2.6f518e43.md
@@ -10,7 +10,7 @@
 ```
 ❌ FILE_REFERENCES
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • Project/Group B/AViewController.xib
   • Project/Group B/AnotherObjcClass.h
@@ -19,10 +19,13 @@
   • ProjectTests/BarTests.swift
   • ProjectUITests/LoginTests.swift
   • ProjectUITests/Screenshots/empty.png
+  • libMismatchingLibrary.a
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
+  • MismatchingLibrary.framework
+  • MismatchingLibrary/MismatchingLibrary-Info.plist
   • NewFramework.framework
   • NewFramework/Info.plist
   • NewFramework/NewFramework.h
@@ -101,6 +104,11 @@
 
 ❌ SETTINGS > "Project" target > "Debug" configuration > Values
 
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
+
 ⚠️  Value mismatch (1):
 
   • CUSTOM_SETTING_COMMON
@@ -110,6 +118,11 @@
 
 ✅ SETTINGS > "Project" target > "Release" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Release" configuration > Values
+
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
 
 ⚠️  Value mismatch (1):
 
@@ -121,7 +134,7 @@
 ❌ SOURCE_TREES > Root project
 Output format: (<path>, <name>, <source_tree>)
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • (AViewController.xib, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
   • (AnotherObjcClass.h, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
@@ -129,15 +142,18 @@ Output format: (<path>, <name>, <source_tree>)
   • (BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
   • (empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
   • (Header4.h, nil, <group>) → (ProjectFramework, nil, <group>) → (nil, nil, <group>)
   • (Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
@@ -147,8 +163,9 @@ Output format: (<path>, <name>, <source_tree>)
 
 ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 
@@ -161,8 +178,9 @@ Output format: (<path>, <name>, <source_tree>)
 
 ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 

--- a/CommandTests/Generated/p1_p2_console_format.2.9841a8d7.md
+++ b/CommandTests/Generated/p1_p2_console_format.2.9841a8d7.md
@@ -11,14 +11,17 @@
 ❌ FILE_REFERENCES
 ❌ TARGETS > NATIVE targets
 ❌ TARGETS > AGGREGATE targets
+❌ HEADERS > "MismatchingLibrary" target
 ✅ HEADERS > "Project" target
 ❌ HEADERS > "ProjectFramework" target
 ✅ HEADERS > "ProjectTests" target
 ✅ HEADERS > "ProjectUITests" target
+✅ SOURCES > "MismatchingLibrary" target
 ❌ SOURCES > "Project" target
 ✅ SOURCES > "ProjectFramework" target
 ❌ SOURCES > "ProjectTests" target
 ❌ SOURCES > "ProjectUITests" target
+✅ RESOURCES > "MismatchingLibrary" target
 ❌ RESOURCES > "Project" target
 ✅ RESOURCES > "ProjectFramework" target
 ❌ RESOURCES > "ProjectTests" target
@@ -28,14 +31,18 @@
 ❌ SETTINGS > Root project > "Debug" configuration > Values
 ✅ SETTINGS > Root project > "Release" configuration > Base configuration
 ❌ SETTINGS > Root project > "Release" configuration > Values
+✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Values
+✅ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Values
 ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Debug" configuration > Values
 ✅ SETTINGS > "Project" target > "Release" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Release" configuration > Values
 ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
 ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Base configuration
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Values
 ✅ SETTINGS > "ProjectTests" target > "Release" configuration > Base configuration
@@ -45,6 +52,8 @@
 ✅ SETTINGS > "ProjectUITests" target > "Release" configuration > Base configuration
 ✅ SETTINGS > "ProjectUITests" target > "Release" configuration > Values
 ❌ SOURCE_TREES > Root project
+✅ DEPENDENCIES > "MismatchingLibrary" target > Linked Dependencies
+✅ DEPENDENCIES > "MismatchingLibrary" target > Embedded Frameworks
 ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 ✅ DEPENDENCIES > "ProjectFramework" target > Linked Dependencies

--- a/CommandTests/Generated/p1_p2_console_format_verbose.2.40a241bd.md
+++ b/CommandTests/Generated/p1_p2_console_format_verbose.2.40a241bd.md
@@ -10,7 +10,7 @@
 ```
 ❌ FILE_REFERENCES
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • Project/Group B/AViewController.xib
   • Project/Group B/AnotherObjcClass.h
@@ -19,10 +19,13 @@
   • ProjectTests/BarTests.swift
   • ProjectUITests/LoginTests.swift
   • ProjectUITests/Screenshots/empty.png
+  • libMismatchingLibrary.a
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
+  • MismatchingLibrary.framework
+  • MismatchingLibrary/MismatchingLibrary-Info.plist
   • NewFramework.framework
   • NewFramework/Info.plist
   • NewFramework/NewFramework.h
@@ -41,11 +44,25 @@
   • NewFramework
 
 
+⚠️  Value mismatch (1):
+
+  • MismatchingLibrary product type
+    ◦ com.apple.product-type.library.static
+    ◦ com.apple.product-type.framework
+
+
 ❌ TARGETS > AGGREGATE targets
 
 ⚠️  Only in second (1):
 
   • NewAggregate
+
+
+❌ HEADERS > "MismatchingLibrary" target
+
+⚠️  Only in second (1):
+
+  • MismatchingLibrary/MismatchingLibrary.h
 
 
 ✅ HEADERS > "Project" target
@@ -69,6 +86,7 @@
 
 ✅ HEADERS > "ProjectTests" target
 ✅ HEADERS > "ProjectUITests" target
+✅ SOURCES > "MismatchingLibrary" target
 ❌ SOURCES > "Project" target
 
 ⚠️  Only in first (1):
@@ -103,6 +121,7 @@
   • ProjectUITests/MetricsTests.swift
 
 
+✅ RESOURCES > "MismatchingLibrary" target
 ❌ RESOURCES > "Project" target
 
 ⚠️  Only in first (2):
@@ -157,6 +176,69 @@
   • CUSTOM_SETTGING_1
 
 
+✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Values
+
+⚠️  Only in first (1):
+
+  • OTHER_LDFLAGS
+
+
+⚠️  Only in second (13):
+
+  • CLANG_ENABLE_MODULES
+  • CURRENT_PROJECT_VERSION
+  • DEFINES_MODULE
+  • DYLIB_COMPATIBILITY_VERSION
+  • DYLIB_CURRENT_VERSION
+  • DYLIB_INSTALL_NAME_BASE
+  • INFOPLIST_FILE
+  • INSTALL_PATH
+  • LD_RUNPATH_SEARCH_PATHS
+  • PRODUCT_BUNDLE_IDENTIFIER
+  • SWIFT_OPTIMIZATION_LEVEL
+  • VERSIONING_SYSTEM
+  • VERSION_INFO_PREFIX
+
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_NAME
+    ◦ $(TARGET_NAME)
+    ◦ $(TARGET_NAME:c99extidentifier)
+
+
+✅ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Values
+
+⚠️  Only in first (1):
+
+  • OTHER_LDFLAGS
+
+
+⚠️  Only in second (12):
+
+  • CLANG_ENABLE_MODULES
+  • CURRENT_PROJECT_VERSION
+  • DEFINES_MODULE
+  • DYLIB_COMPATIBILITY_VERSION
+  • DYLIB_CURRENT_VERSION
+  • DYLIB_INSTALL_NAME_BASE
+  • INFOPLIST_FILE
+  • INSTALL_PATH
+  • LD_RUNPATH_SEARCH_PATHS
+  • PRODUCT_BUNDLE_IDENTIFIER
+  • VERSIONING_SYSTEM
+  • VERSION_INFO_PREFIX
+
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_NAME
+    ◦ $(TARGET_NAME)
+    ◦ $(TARGET_NAME:c99extidentifier)
+
+
 ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
 
 ⚠️  Value mismatch (1):
@@ -168,6 +250,11 @@
 
 ❌ SETTINGS > "Project" target > "Debug" configuration > Values
 
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
+
 ⚠️  Value mismatch (1):
 
   • CUSTOM_SETTING_COMMON
@@ -178,6 +265,11 @@
 ✅ SETTINGS > "Project" target > "Release" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Release" configuration > Values
 
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
+
 ⚠️  Value mismatch (1):
 
   • CUSTOM_SETTING_COMMON
@@ -186,9 +278,25 @@
 
 
 ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_BUNDLE_IDENTIFIER
+    ◦ com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework
+    ◦ com.bloomberg.xcdiff.Project.ProjectFramework
+
+
 ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_BUNDLE_IDENTIFIER
+    ◦ com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework
+    ◦ com.bloomberg.xcdiff.Project.ProjectFramework
+
+
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Base configuration
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Values
 ✅ SETTINGS > "ProjectTests" target > "Release" configuration > Base configuration
@@ -200,7 +308,7 @@
 ❌ SOURCE_TREES > Root project
 Output format: (<path>, <name>, <source_tree>)
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • (AViewController.xib, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
   • (AnotherObjcClass.h, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
@@ -208,15 +316,18 @@ Output format: (<path>, <name>, <source_tree>)
   • (BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
   • (empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
   • (Header4.h, nil, <group>) → (ProjectFramework, nil, <group>) → (nil, nil, <group>)
   • (Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
@@ -224,10 +335,13 @@ Output format: (<path>, <name>, <source_tree>)
   • (Target.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
 
 
+✅ DEPENDENCIES > "MismatchingLibrary" target > Linked Dependencies
+✅ DEPENDENCIES > "MismatchingLibrary" target > Embedded Frameworks
 ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 
@@ -240,8 +354,9 @@ Output format: (<path>, <name>, <source_tree>)
 
 ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 

--- a/CommandTests/Generated/p1_p2_dependencies_tag.2.7c06a18b.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag.2.7c06a18b.md
@@ -8,6 +8,8 @@
 
 # Expected output
 ```
+✅ DEPENDENCIES > "MismatchingLibrary" target > Linked Dependencies
+✅ DEPENDENCIES > "MismatchingLibrary" target > Embedded Frameworks
 ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 ✅ DEPENDENCIES > "ProjectFramework" target > Linked Dependencies

--- a/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target.1.3eb2ea13.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target.1.3eb2ea13.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target_console_format.1.c8582a4c.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target_console_format.1.c8582a4c.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target_console_format_verbose.1.c2d04e87.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target_console_format_verbose.1.c2d04e87.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target_json_format.1.6df24ec4.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target_json_format.1.6df24ec4.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target_json_format_verbose.1.1393d41a.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target_json_format_verbose.1.1393d41a.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target_markdown_format.1.ede88349.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target_markdown_format.1.ede88349.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target_markdown_format_verbose.1.00f8707a.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target_markdown_format_verbose.1.00f8707a.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target_verbose.1.ddfd5e6a.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_NewFramework_target_verbose.1.ddfd5e6a.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_console_format_verbose.2.2848daea.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_console_format_verbose.2.2848daea.md
@@ -10,8 +10,9 @@
 ```
 ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 
@@ -24,8 +25,9 @@
 
 ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 

--- a/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_json_format.2.66701d7e.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_json_format.2.66701d7e.md
@@ -25,6 +25,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"
@@ -41,6 +42,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"

--- a/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_json_format_verbose.2.8bc3f1c5.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_json_format_verbose.2.8bc3f1c5.md
@@ -25,6 +25,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"
@@ -41,6 +42,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"

--- a/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_markdown_format_verbose.2.139e5b3b.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_markdown_format_verbose.2.139e5b3b.md
@@ -12,8 +12,9 @@
 ## ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 
 
-### ⚠️  Only in second (1):
+### ⚠️  Only in second (2):
 
+  - `MismatchingLibrary.framework`
   - `NewFramework.framework`
 
 
@@ -28,8 +29,9 @@
 ## ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 
 
-### ⚠️  Only in second (1):
+### ⚠️  Only in second (2):
 
+  - `MismatchingLibrary.framework`
   - `NewFramework.framework`
 
 

--- a/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_verbose.2.abaed34d.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_verbose.2.abaed34d.md
@@ -10,8 +10,9 @@
 ```
 ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 
@@ -24,8 +25,9 @@
 
 ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 

--- a/CommandTests/Generated/p1_p2_dependencies_tag_console_format.2.02bbb833.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_console_format.2.02bbb833.md
@@ -8,6 +8,8 @@
 
 # Expected output
 ```
+✅ DEPENDENCIES > "MismatchingLibrary" target > Linked Dependencies
+✅ DEPENDENCIES > "MismatchingLibrary" target > Embedded Frameworks
 ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 ✅ DEPENDENCIES > "ProjectFramework" target > Linked Dependencies

--- a/CommandTests/Generated/p1_p2_dependencies_tag_console_format_verbose.2.b4701bc2.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_console_format_verbose.2.b4701bc2.md
@@ -8,10 +8,13 @@
 
 # Expected output
 ```
+✅ DEPENDENCIES > "MismatchingLibrary" target > Linked Dependencies
+✅ DEPENDENCIES > "MismatchingLibrary" target > Embedded Frameworks
 ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 
@@ -24,8 +27,9 @@
 
 ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 

--- a/CommandTests/Generated/p1_p2_dependencies_tag_json_format.2.fd062de6.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_json_format.2.fd062de6.md
@@ -11,6 +11,38 @@
 [
   {
     "context" : [
+      "\"MismatchingLibrary\" target",
+      "Linked Dependencies"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "dependencies"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "Embedded Frameworks"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "dependencies"
+  },
+  {
+    "context" : [
       "\"Project\" target",
       "Linked Dependencies"
     ],
@@ -25,6 +57,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"
@@ -41,6 +74,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"

--- a/CommandTests/Generated/p1_p2_dependencies_tag_json_format_verbose.2.e461e65d.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_json_format_verbose.2.e461e65d.md
@@ -11,6 +11,38 @@
 [
   {
     "context" : [
+      "\"MismatchingLibrary\" target",
+      "Linked Dependencies"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "dependencies"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "Embedded Frameworks"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "dependencies"
+  },
+  {
+    "context" : [
       "\"Project\" target",
       "Linked Dependencies"
     ],
@@ -25,6 +57,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"
@@ -41,6 +74,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"

--- a/CommandTests/Generated/p1_p2_dependencies_tag_markdown_format.2.dbbead25.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_markdown_format.2.dbbead25.md
@@ -9,6 +9,12 @@
 # Expected output
 ```
 
+## ✅ DEPENDENCIES > "MismatchingLibrary" target > Linked Dependencies
+
+
+## ✅ DEPENDENCIES > "MismatchingLibrary" target > Embedded Frameworks
+
+
 ## ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 
 

--- a/CommandTests/Generated/p1_p2_dependencies_tag_markdown_format_verbose.2.af50e3c0.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_markdown_format_verbose.2.af50e3c0.md
@@ -9,11 +9,18 @@
 # Expected output
 ```
 
+## ✅ DEPENDENCIES > "MismatchingLibrary" target > Linked Dependencies
+
+
+## ✅ DEPENDENCIES > "MismatchingLibrary" target > Embedded Frameworks
+
+
 ## ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 
 
-### ⚠️  Only in second (1):
+### ⚠️  Only in second (2):
 
+  - `MismatchingLibrary.framework`
   - `NewFramework.framework`
 
 
@@ -28,8 +35,9 @@
 ## ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 
 
-### ⚠️  Only in second (1):
+### ⚠️  Only in second (2):
 
+  - `MismatchingLibrary.framework`
   - `NewFramework.framework`
 
 

--- a/CommandTests/Generated/p1_p2_dependencies_tag_verbose.2.023c5888.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_verbose.2.023c5888.md
@@ -8,10 +8,13 @@
 
 # Expected output
 ```
+✅ DEPENDENCIES > "MismatchingLibrary" target > Linked Dependencies
+✅ DEPENDENCIES > "MismatchingLibrary" target > Embedded Frameworks
 ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 
@@ -24,8 +27,9 @@
 
 ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 

--- a/CommandTests/Generated/p1_p2_file_references_tag_NewFramework_target_console_format_verbose.2.eb491ad4.md
+++ b/CommandTests/Generated/p1_p2_file_references_tag_NewFramework_target_console_format_verbose.2.eb491ad4.md
@@ -10,7 +10,7 @@
 ```
 ❌ FILE_REFERENCES
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • Project/Group B/AViewController.xib
   • Project/Group B/AnotherObjcClass.h
@@ -19,10 +19,13 @@
   • ProjectTests/BarTests.swift
   • ProjectUITests/LoginTests.swift
   • ProjectUITests/Screenshots/empty.png
+  • libMismatchingLibrary.a
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
+  • MismatchingLibrary.framework
+  • MismatchingLibrary/MismatchingLibrary-Info.plist
   • NewFramework.framework
   • NewFramework/Info.plist
   • NewFramework/NewFramework.h

--- a/CommandTests/Generated/p1_p2_file_references_tag_NewFramework_target_json_format.2.de76ed81.md
+++ b/CommandTests/Generated/p1_p2_file_references_tag_NewFramework_target_json_format.2.de76ed81.md
@@ -23,9 +23,12 @@
       "Project\/Resources\/time.png",
       "ProjectTests\/BarTests.swift",
       "ProjectUITests\/LoginTests.swift",
-      "ProjectUITests\/Screenshots\/empty.png"
+      "ProjectUITests\/Screenshots\/empty.png",
+      "libMismatchingLibrary.a"
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
+      "MismatchingLibrary\/MismatchingLibrary-Info.plist",
       "NewFramework.framework",
       "NewFramework\/Info.plist",
       "NewFramework\/NewFramework.h",

--- a/CommandTests/Generated/p1_p2_file_references_tag_NewFramework_target_json_format_verbose.2.6a7f139e.md
+++ b/CommandTests/Generated/p1_p2_file_references_tag_NewFramework_target_json_format_verbose.2.6a7f139e.md
@@ -23,9 +23,12 @@
       "Project\/Resources\/time.png",
       "ProjectTests\/BarTests.swift",
       "ProjectUITests\/LoginTests.swift",
-      "ProjectUITests\/Screenshots\/empty.png"
+      "ProjectUITests\/Screenshots\/empty.png",
+      "libMismatchingLibrary.a"
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
+      "MismatchingLibrary\/MismatchingLibrary-Info.plist",
       "NewFramework.framework",
       "NewFramework\/Info.plist",
       "NewFramework\/NewFramework.h",

--- a/CommandTests/Generated/p1_p2_file_references_tag_NewFramework_target_markdown_format_verbose.2.ba33f835.md
+++ b/CommandTests/Generated/p1_p2_file_references_tag_NewFramework_target_markdown_format_verbose.2.ba33f835.md
@@ -12,7 +12,7 @@
 ## ❌ FILE_REFERENCES
 
 
-### ⚠️  Only in first (7):
+### ⚠️  Only in first (8):
 
   - `Project/Group B/AViewController.xib`
   - `Project/Group B/AnotherObjcClass.h`
@@ -21,10 +21,13 @@
   - `ProjectTests/BarTests.swift`
   - `ProjectUITests/LoginTests.swift`
   - `ProjectUITests/Screenshots/empty.png`
+  - `libMismatchingLibrary.a`
 
 
-### ⚠️  Only in second (9):
+### ⚠️  Only in second (11):
 
+  - `MismatchingLibrary.framework`
+  - `MismatchingLibrary/MismatchingLibrary-Info.plist`
   - `NewFramework.framework`
   - `NewFramework/Info.plist`
   - `NewFramework/NewFramework.h`

--- a/CommandTests/Generated/p1_p2_file_references_tag_NewFramework_target_verbose.2.d69d2f1c.md
+++ b/CommandTests/Generated/p1_p2_file_references_tag_NewFramework_target_verbose.2.d69d2f1c.md
@@ -10,7 +10,7 @@
 ```
 ❌ FILE_REFERENCES
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • Project/Group B/AViewController.xib
   • Project/Group B/AnotherObjcClass.h
@@ -19,10 +19,13 @@
   • ProjectTests/BarTests.swift
   • ProjectUITests/LoginTests.swift
   • ProjectUITests/Screenshots/empty.png
+  • libMismatchingLibrary.a
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
+  • MismatchingLibrary.framework
+  • MismatchingLibrary/MismatchingLibrary-Info.plist
   • NewFramework.framework
   • NewFramework/Info.plist
   • NewFramework/NewFramework.h

--- a/CommandTests/Generated/p1_p2_file_references_tag_Project_target_console_format_verbose.2.b154eaa6.md
+++ b/CommandTests/Generated/p1_p2_file_references_tag_Project_target_console_format_verbose.2.b154eaa6.md
@@ -10,7 +10,7 @@
 ```
 ❌ FILE_REFERENCES
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • Project/Group B/AViewController.xib
   • Project/Group B/AnotherObjcClass.h
@@ -19,10 +19,13 @@
   • ProjectTests/BarTests.swift
   • ProjectUITests/LoginTests.swift
   • ProjectUITests/Screenshots/empty.png
+  • libMismatchingLibrary.a
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
+  • MismatchingLibrary.framework
+  • MismatchingLibrary/MismatchingLibrary-Info.plist
   • NewFramework.framework
   • NewFramework/Info.plist
   • NewFramework/NewFramework.h

--- a/CommandTests/Generated/p1_p2_file_references_tag_Project_target_json_format.2.917e4b62.md
+++ b/CommandTests/Generated/p1_p2_file_references_tag_Project_target_json_format.2.917e4b62.md
@@ -23,9 +23,12 @@
       "Project\/Resources\/time.png",
       "ProjectTests\/BarTests.swift",
       "ProjectUITests\/LoginTests.swift",
-      "ProjectUITests\/Screenshots\/empty.png"
+      "ProjectUITests\/Screenshots\/empty.png",
+      "libMismatchingLibrary.a"
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
+      "MismatchingLibrary\/MismatchingLibrary-Info.plist",
       "NewFramework.framework",
       "NewFramework\/Info.plist",
       "NewFramework\/NewFramework.h",

--- a/CommandTests/Generated/p1_p2_file_references_tag_Project_target_json_format_verbose.2.104e99fe.md
+++ b/CommandTests/Generated/p1_p2_file_references_tag_Project_target_json_format_verbose.2.104e99fe.md
@@ -23,9 +23,12 @@
       "Project\/Resources\/time.png",
       "ProjectTests\/BarTests.swift",
       "ProjectUITests\/LoginTests.swift",
-      "ProjectUITests\/Screenshots\/empty.png"
+      "ProjectUITests\/Screenshots\/empty.png",
+      "libMismatchingLibrary.a"
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
+      "MismatchingLibrary\/MismatchingLibrary-Info.plist",
       "NewFramework.framework",
       "NewFramework\/Info.plist",
       "NewFramework\/NewFramework.h",

--- a/CommandTests/Generated/p1_p2_file_references_tag_Project_target_markdown_format_verbose.2.70720c9b.md
+++ b/CommandTests/Generated/p1_p2_file_references_tag_Project_target_markdown_format_verbose.2.70720c9b.md
@@ -12,7 +12,7 @@
 ## ❌ FILE_REFERENCES
 
 
-### ⚠️  Only in first (7):
+### ⚠️  Only in first (8):
 
   - `Project/Group B/AViewController.xib`
   - `Project/Group B/AnotherObjcClass.h`
@@ -21,10 +21,13 @@
   - `ProjectTests/BarTests.swift`
   - `ProjectUITests/LoginTests.swift`
   - `ProjectUITests/Screenshots/empty.png`
+  - `libMismatchingLibrary.a`
 
 
-### ⚠️  Only in second (9):
+### ⚠️  Only in second (11):
 
+  - `MismatchingLibrary.framework`
+  - `MismatchingLibrary/MismatchingLibrary-Info.plist`
   - `NewFramework.framework`
   - `NewFramework/Info.plist`
   - `NewFramework/NewFramework.h`

--- a/CommandTests/Generated/p1_p2_file_references_tag_Project_target_verbose.2.c9193e01.md
+++ b/CommandTests/Generated/p1_p2_file_references_tag_Project_target_verbose.2.c9193e01.md
@@ -10,7 +10,7 @@
 ```
 ❌ FILE_REFERENCES
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • Project/Group B/AViewController.xib
   • Project/Group B/AnotherObjcClass.h
@@ -19,10 +19,13 @@
   • ProjectTests/BarTests.swift
   • ProjectUITests/LoginTests.swift
   • ProjectUITests/Screenshots/empty.png
+  • libMismatchingLibrary.a
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
+  • MismatchingLibrary.framework
+  • MismatchingLibrary/MismatchingLibrary-Info.plist
   • NewFramework.framework
   • NewFramework/Info.plist
   • NewFramework/NewFramework.h

--- a/CommandTests/Generated/p1_p2_file_references_tag_console_format_verbose.2.0a56ded7.md
+++ b/CommandTests/Generated/p1_p2_file_references_tag_console_format_verbose.2.0a56ded7.md
@@ -10,7 +10,7 @@
 ```
 ❌ FILE_REFERENCES
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • Project/Group B/AViewController.xib
   • Project/Group B/AnotherObjcClass.h
@@ -19,10 +19,13 @@
   • ProjectTests/BarTests.swift
   • ProjectUITests/LoginTests.swift
   • ProjectUITests/Screenshots/empty.png
+  • libMismatchingLibrary.a
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
+  • MismatchingLibrary.framework
+  • MismatchingLibrary/MismatchingLibrary-Info.plist
   • NewFramework.framework
   • NewFramework/Info.plist
   • NewFramework/NewFramework.h

--- a/CommandTests/Generated/p1_p2_file_references_tag_json_format.2.4606ec1f.md
+++ b/CommandTests/Generated/p1_p2_file_references_tag_json_format.2.4606ec1f.md
@@ -23,9 +23,12 @@
       "Project\/Resources\/time.png",
       "ProjectTests\/BarTests.swift",
       "ProjectUITests\/LoginTests.swift",
-      "ProjectUITests\/Screenshots\/empty.png"
+      "ProjectUITests\/Screenshots\/empty.png",
+      "libMismatchingLibrary.a"
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
+      "MismatchingLibrary\/MismatchingLibrary-Info.plist",
       "NewFramework.framework",
       "NewFramework\/Info.plist",
       "NewFramework\/NewFramework.h",

--- a/CommandTests/Generated/p1_p2_file_references_tag_json_format_verbose.2.99c181fe.md
+++ b/CommandTests/Generated/p1_p2_file_references_tag_json_format_verbose.2.99c181fe.md
@@ -23,9 +23,12 @@
       "Project\/Resources\/time.png",
       "ProjectTests\/BarTests.swift",
       "ProjectUITests\/LoginTests.swift",
-      "ProjectUITests\/Screenshots\/empty.png"
+      "ProjectUITests\/Screenshots\/empty.png",
+      "libMismatchingLibrary.a"
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
+      "MismatchingLibrary\/MismatchingLibrary-Info.plist",
       "NewFramework.framework",
       "NewFramework\/Info.plist",
       "NewFramework\/NewFramework.h",

--- a/CommandTests/Generated/p1_p2_file_references_tag_markdown_format_verbose.2.6eada30a.md
+++ b/CommandTests/Generated/p1_p2_file_references_tag_markdown_format_verbose.2.6eada30a.md
@@ -12,7 +12,7 @@
 ## ❌ FILE_REFERENCES
 
 
-### ⚠️  Only in first (7):
+### ⚠️  Only in first (8):
 
   - `Project/Group B/AViewController.xib`
   - `Project/Group B/AnotherObjcClass.h`
@@ -21,10 +21,13 @@
   - `ProjectTests/BarTests.swift`
   - `ProjectUITests/LoginTests.swift`
   - `ProjectUITests/Screenshots/empty.png`
+  - `libMismatchingLibrary.a`
 
 
-### ⚠️  Only in second (9):
+### ⚠️  Only in second (11):
 
+  - `MismatchingLibrary.framework`
+  - `MismatchingLibrary/MismatchingLibrary-Info.plist`
   - `NewFramework.framework`
   - `NewFramework/Info.plist`
   - `NewFramework/NewFramework.h`

--- a/CommandTests/Generated/p1_p2_file_references_tag_verbose.2.f3ef9001.md
+++ b/CommandTests/Generated/p1_p2_file_references_tag_verbose.2.f3ef9001.md
@@ -10,7 +10,7 @@
 ```
 ❌ FILE_REFERENCES
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • Project/Group B/AViewController.xib
   • Project/Group B/AnotherObjcClass.h
@@ -19,10 +19,13 @@
   • ProjectTests/BarTests.swift
   • ProjectUITests/LoginTests.swift
   • ProjectUITests/Screenshots/empty.png
+  • libMismatchingLibrary.a
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
+  • MismatchingLibrary.framework
+  • MismatchingLibrary/MismatchingLibrary-Info.plist
   • NewFramework.framework
   • NewFramework/Info.plist
   • NewFramework/NewFramework.h

--- a/CommandTests/Generated/p1_p2_headers_tag.2.d1be72ae.md
+++ b/CommandTests/Generated/p1_p2_headers_tag.2.d1be72ae.md
@@ -8,6 +8,7 @@
 
 # Expected output
 ```
+❌ HEADERS > "MismatchingLibrary" target
 ✅ HEADERS > "Project" target
 ❌ HEADERS > "ProjectFramework" target
 ✅ HEADERS > "ProjectTests" target

--- a/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target.1.7d3a003d.md
+++ b/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target.1.7d3a003d.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target_console_format.1.1a3c9d1f.md
+++ b/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target_console_format.1.1a3c9d1f.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target_console_format_verbose.1.49ee3509.md
+++ b/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target_console_format_verbose.1.49ee3509.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target_json_format.1.b33272ad.md
+++ b/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target_json_format.1.b33272ad.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target_json_format_verbose.1.26e4f275.md
+++ b/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target_json_format_verbose.1.26e4f275.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target_markdown_format.1.5b6dbf3f.md
+++ b/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target_markdown_format.1.5b6dbf3f.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target_markdown_format_verbose.1.3c1cfba2.md
+++ b/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target_markdown_format_verbose.1.3c1cfba2.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target_verbose.1.1645eba3.md
+++ b/CommandTests/Generated/p1_p2_headers_tag_NewFramework_target_verbose.1.1645eba3.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_headers_tag_console_format.2.3b586ea2.md
+++ b/CommandTests/Generated/p1_p2_headers_tag_console_format.2.3b586ea2.md
@@ -8,6 +8,7 @@
 
 # Expected output
 ```
+❌ HEADERS > "MismatchingLibrary" target
 ✅ HEADERS > "Project" target
 ❌ HEADERS > "ProjectFramework" target
 ✅ HEADERS > "ProjectTests" target

--- a/CommandTests/Generated/p1_p2_headers_tag_console_format_verbose.2.db45e192.md
+++ b/CommandTests/Generated/p1_p2_headers_tag_console_format_verbose.2.db45e192.md
@@ -8,6 +8,13 @@
 
 # Expected output
 ```
+❌ HEADERS > "MismatchingLibrary" target
+
+⚠️  Only in second (1):
+
+  • MismatchingLibrary/MismatchingLibrary.h
+
+
 ✅ HEADERS > "Project" target
 ❌ HEADERS > "ProjectFramework" target
 

--- a/CommandTests/Generated/p1_p2_headers_tag_json_format.2.6e8872a1.md
+++ b/CommandTests/Generated/p1_p2_headers_tag_json_format.2.6e8872a1.md
@@ -11,6 +11,21 @@
 [
   {
     "context" : [
+      "\"MismatchingLibrary\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+      "MismatchingLibrary\/MismatchingLibrary.h"
+    ],
+    "tag" : "headers"
+  },
+  {
+    "context" : [
       "\"Project\" target"
     ],
     "differentValues" : [

--- a/CommandTests/Generated/p1_p2_headers_tag_json_format_verbose.2.1c535abb.md
+++ b/CommandTests/Generated/p1_p2_headers_tag_json_format_verbose.2.1c535abb.md
@@ -11,6 +11,21 @@
 [
   {
     "context" : [
+      "\"MismatchingLibrary\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+      "MismatchingLibrary\/MismatchingLibrary.h"
+    ],
+    "tag" : "headers"
+  },
+  {
+    "context" : [
       "\"Project\" target"
     ],
     "differentValues" : [

--- a/CommandTests/Generated/p1_p2_headers_tag_markdown_format.2.faef272e.md
+++ b/CommandTests/Generated/p1_p2_headers_tag_markdown_format.2.faef272e.md
@@ -9,6 +9,9 @@
 # Expected output
 ```
 
+## ❌ HEADERS > "MismatchingLibrary" target
+
+
 ## ✅ HEADERS > "Project" target
 
 

--- a/CommandTests/Generated/p1_p2_headers_tag_markdown_format_verbose.2.1aab2451.md
+++ b/CommandTests/Generated/p1_p2_headers_tag_markdown_format_verbose.2.1aab2451.md
@@ -9,6 +9,15 @@
 # Expected output
 ```
 
+## ❌ HEADERS > "MismatchingLibrary" target
+
+
+### ⚠️  Only in second (1):
+
+  - `MismatchingLibrary/MismatchingLibrary.h`
+
+
+
 ## ✅ HEADERS > "Project" target
 
 

--- a/CommandTests/Generated/p1_p2_headers_tag_verbose.2.6cdf87d7.md
+++ b/CommandTests/Generated/p1_p2_headers_tag_verbose.2.6cdf87d7.md
@@ -8,6 +8,13 @@
 
 # Expected output
 ```
+❌ HEADERS > "MismatchingLibrary" target
+
+⚠️  Only in second (1):
+
+  • MismatchingLibrary/MismatchingLibrary.h
+
+
 ✅ HEADERS > "Project" target
 ❌ HEADERS > "ProjectFramework" target
 

--- a/CommandTests/Generated/p1_p2_json_format.2.e54c06ce.md
+++ b/CommandTests/Generated/p1_p2_json_format.2.e54c06ce.md
@@ -23,9 +23,12 @@
       "Project\/Resources\/time.png",
       "ProjectTests\/BarTests.swift",
       "ProjectUITests\/LoginTests.swift",
-      "ProjectUITests\/Screenshots\/empty.png"
+      "ProjectUITests\/Screenshots\/empty.png",
+      "libMismatchingLibrary.a"
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
+      "MismatchingLibrary\/MismatchingLibrary-Info.plist",
       "NewFramework.framework",
       "NewFramework\/Info.plist",
       "NewFramework\/NewFramework.h",
@@ -43,7 +46,11 @@
       "NATIVE targets"
     ],
     "differentValues" : [
-
+      {
+        "context" : "MismatchingLibrary product type",
+        "first" : "com.apple.product-type.library.static",
+        "second" : "com.apple.product-type.framework"
+      }
     ],
     "onlyInFirst" : [
 
@@ -67,6 +74,21 @@
       "NewAggregate"
     ],
     "tag" : "targets"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+      "MismatchingLibrary\/MismatchingLibrary.h"
+    ],
+    "tag" : "headers"
   },
   {
     "context" : [
@@ -139,6 +161,21 @@
   },
   {
     "context" : [
+      "\"MismatchingLibrary\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "sources"
+  },
+  {
+    "context" : [
       "\"Project\" target"
     ],
     "differentValues" : [
@@ -200,6 +237,21 @@
       "ProjectUITests\/MetricsTests.swift"
     ],
     "tag" : "sources"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "resources"
   },
   {
     "context" : [
@@ -351,6 +403,105 @@
   },
   {
     "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Debug\" configuration",
+      "Base configuration"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Debug\" configuration",
+      "Values"
+    ],
+    "differentValues" : [
+      {
+        "context" : "PRODUCT_NAME",
+        "first" : "$(TARGET_NAME)",
+        "second" : "$(TARGET_NAME:c99extidentifier)"
+      }
+    ],
+    "onlyInFirst" : [
+      "OTHER_LDFLAGS"
+    ],
+    "onlyInSecond" : [
+      "CLANG_ENABLE_MODULES",
+      "CURRENT_PROJECT_VERSION",
+      "DEFINES_MODULE",
+      "DYLIB_COMPATIBILITY_VERSION",
+      "DYLIB_CURRENT_VERSION",
+      "DYLIB_INSTALL_NAME_BASE",
+      "INFOPLIST_FILE",
+      "INSTALL_PATH",
+      "LD_RUNPATH_SEARCH_PATHS",
+      "PRODUCT_BUNDLE_IDENTIFIER",
+      "SWIFT_OPTIMIZATION_LEVEL",
+      "VERSIONING_SYSTEM",
+      "VERSION_INFO_PREFIX"
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Release\" configuration",
+      "Base configuration"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Release\" configuration",
+      "Values"
+    ],
+    "differentValues" : [
+      {
+        "context" : "PRODUCT_NAME",
+        "first" : "$(TARGET_NAME)",
+        "second" : "$(TARGET_NAME:c99extidentifier)"
+      }
+    ],
+    "onlyInFirst" : [
+      "OTHER_LDFLAGS"
+    ],
+    "onlyInSecond" : [
+      "CLANG_ENABLE_MODULES",
+      "CURRENT_PROJECT_VERSION",
+      "DEFINES_MODULE",
+      "DYLIB_COMPATIBILITY_VERSION",
+      "DYLIB_CURRENT_VERSION",
+      "DYLIB_INSTALL_NAME_BASE",
+      "INFOPLIST_FILE",
+      "INSTALL_PATH",
+      "LD_RUNPATH_SEARCH_PATHS",
+      "PRODUCT_BUNDLE_IDENTIFIER",
+      "VERSIONING_SYSTEM",
+      "VERSION_INFO_PREFIX"
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
       "\"Project\" target",
       "\"Debug\" configuration",
       "Base configuration"
@@ -387,7 +538,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   },
@@ -425,7 +576,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   },
@@ -453,7 +604,11 @@
       "Values"
     ],
     "differentValues" : [
-
+      {
+        "context" : "PRODUCT_BUNDLE_IDENTIFIER",
+        "first" : "com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework",
+        "second" : "com.bloomberg.xcdiff.Project.ProjectFramework"
+      }
     ],
     "onlyInFirst" : [
 
@@ -487,7 +642,11 @@
       "Values"
     ],
     "differentValues" : [
-
+      {
+        "context" : "PRODUCT_BUNDLE_IDENTIFIER",
+        "first" : "com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework",
+        "second" : "com.bloomberg.xcdiff.Project.ProjectFramework"
+      }
     ],
     "onlyInFirst" : [
 
@@ -648,6 +807,7 @@
       "(BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
       "(empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)"
     ],
     "onlyInSecond" : [
@@ -655,6 +815,8 @@
       "(Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)",
@@ -662,6 +824,38 @@
       "(Target.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)"
     ],
     "tag" : "source_trees"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "Linked Dependencies"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "dependencies"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "Embedded Frameworks"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "dependencies"
   },
   {
     "context" : [
@@ -679,6 +873,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"
@@ -695,6 +890,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"

--- a/CommandTests/Generated/p1_p2_json_format_verbose.2.0e0a3eb6.md
+++ b/CommandTests/Generated/p1_p2_json_format_verbose.2.0e0a3eb6.md
@@ -23,9 +23,12 @@
       "Project\/Resources\/time.png",
       "ProjectTests\/BarTests.swift",
       "ProjectUITests\/LoginTests.swift",
-      "ProjectUITests\/Screenshots\/empty.png"
+      "ProjectUITests\/Screenshots\/empty.png",
+      "libMismatchingLibrary.a"
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
+      "MismatchingLibrary\/MismatchingLibrary-Info.plist",
       "NewFramework.framework",
       "NewFramework\/Info.plist",
       "NewFramework\/NewFramework.h",
@@ -43,7 +46,11 @@
       "NATIVE targets"
     ],
     "differentValues" : [
-
+      {
+        "context" : "MismatchingLibrary product type",
+        "first" : "com.apple.product-type.library.static",
+        "second" : "com.apple.product-type.framework"
+      }
     ],
     "onlyInFirst" : [
 
@@ -67,6 +74,21 @@
       "NewAggregate"
     ],
     "tag" : "targets"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+      "MismatchingLibrary\/MismatchingLibrary.h"
+    ],
+    "tag" : "headers"
   },
   {
     "context" : [
@@ -139,6 +161,21 @@
   },
   {
     "context" : [
+      "\"MismatchingLibrary\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "sources"
+  },
+  {
+    "context" : [
       "\"Project\" target"
     ],
     "differentValues" : [
@@ -200,6 +237,21 @@
       "ProjectUITests\/MetricsTests.swift"
     ],
     "tag" : "sources"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "resources"
   },
   {
     "context" : [
@@ -351,6 +403,105 @@
   },
   {
     "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Debug\" configuration",
+      "Base configuration"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Debug\" configuration",
+      "Values"
+    ],
+    "differentValues" : [
+      {
+        "context" : "PRODUCT_NAME",
+        "first" : "$(TARGET_NAME)",
+        "second" : "$(TARGET_NAME:c99extidentifier)"
+      }
+    ],
+    "onlyInFirst" : [
+      "OTHER_LDFLAGS"
+    ],
+    "onlyInSecond" : [
+      "CLANG_ENABLE_MODULES",
+      "CURRENT_PROJECT_VERSION",
+      "DEFINES_MODULE",
+      "DYLIB_COMPATIBILITY_VERSION",
+      "DYLIB_CURRENT_VERSION",
+      "DYLIB_INSTALL_NAME_BASE",
+      "INFOPLIST_FILE",
+      "INSTALL_PATH",
+      "LD_RUNPATH_SEARCH_PATHS",
+      "PRODUCT_BUNDLE_IDENTIFIER",
+      "SWIFT_OPTIMIZATION_LEVEL",
+      "VERSIONING_SYSTEM",
+      "VERSION_INFO_PREFIX"
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Release\" configuration",
+      "Base configuration"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Release\" configuration",
+      "Values"
+    ],
+    "differentValues" : [
+      {
+        "context" : "PRODUCT_NAME",
+        "first" : "$(TARGET_NAME)",
+        "second" : "$(TARGET_NAME:c99extidentifier)"
+      }
+    ],
+    "onlyInFirst" : [
+      "OTHER_LDFLAGS"
+    ],
+    "onlyInSecond" : [
+      "CLANG_ENABLE_MODULES",
+      "CURRENT_PROJECT_VERSION",
+      "DEFINES_MODULE",
+      "DYLIB_COMPATIBILITY_VERSION",
+      "DYLIB_CURRENT_VERSION",
+      "DYLIB_INSTALL_NAME_BASE",
+      "INFOPLIST_FILE",
+      "INSTALL_PATH",
+      "LD_RUNPATH_SEARCH_PATHS",
+      "PRODUCT_BUNDLE_IDENTIFIER",
+      "VERSIONING_SYSTEM",
+      "VERSION_INFO_PREFIX"
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
       "\"Project\" target",
       "\"Debug\" configuration",
       "Base configuration"
@@ -387,7 +538,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   },
@@ -425,7 +576,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   },
@@ -453,7 +604,11 @@
       "Values"
     ],
     "differentValues" : [
-
+      {
+        "context" : "PRODUCT_BUNDLE_IDENTIFIER",
+        "first" : "com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework",
+        "second" : "com.bloomberg.xcdiff.Project.ProjectFramework"
+      }
     ],
     "onlyInFirst" : [
 
@@ -487,7 +642,11 @@
       "Values"
     ],
     "differentValues" : [
-
+      {
+        "context" : "PRODUCT_BUNDLE_IDENTIFIER",
+        "first" : "com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework",
+        "second" : "com.bloomberg.xcdiff.Project.ProjectFramework"
+      }
     ],
     "onlyInFirst" : [
 
@@ -648,6 +807,7 @@
       "(BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
       "(empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)"
     ],
     "onlyInSecond" : [
@@ -655,6 +815,8 @@
       "(Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)",
@@ -662,6 +824,38 @@
       "(Target.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)"
     ],
     "tag" : "source_trees"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "Linked Dependencies"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "dependencies"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "Embedded Frameworks"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "dependencies"
   },
   {
     "context" : [
@@ -679,6 +873,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"
@@ -695,6 +890,7 @@
 
     ],
     "onlyInSecond" : [
+      "MismatchingLibrary.framework",
       "NewFramework.framework"
     ],
     "tag" : "dependencies"

--- a/CommandTests/Generated/p1_p2_markdown_format.2.1e09644b.md
+++ b/CommandTests/Generated/p1_p2_markdown_format.2.1e09644b.md
@@ -18,6 +18,9 @@
 ## ❌ TARGETS > AGGREGATE targets
 
 
+## ❌ HEADERS > "MismatchingLibrary" target
+
+
 ## ✅ HEADERS > "Project" target
 
 
@@ -30,6 +33,9 @@
 ## ✅ HEADERS > "ProjectUITests" target
 
 
+## ✅ SOURCES > "MismatchingLibrary" target
+
+
 ## ❌ SOURCES > "Project" target
 
 
@@ -40,6 +46,9 @@
 
 
 ## ❌ SOURCES > "ProjectUITests" target
+
+
+## ✅ RESOURCES > "MismatchingLibrary" target
 
 
 ## ❌ RESOURCES > "Project" target
@@ -69,6 +78,18 @@
 ## ❌ SETTINGS > Root project > "Release" configuration > Values
 
 
+## ✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
+
+
+## ❌ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Values
+
+
+## ✅ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Base configuration
+
+
+## ❌ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Values
+
+
 ## ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
 
 
@@ -84,13 +105,13 @@
 ## ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Base configuration
 
 
-## ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+## ❌ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
 
 
 ## ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Base configuration
 
 
-## ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+## ❌ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
 
 
 ## ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Base configuration
@@ -118,6 +139,12 @@
 
 
 ## ❌ SOURCE_TREES > Root project
+
+
+## ✅ DEPENDENCIES > "MismatchingLibrary" target > Linked Dependencies
+
+
+## ✅ DEPENDENCIES > "MismatchingLibrary" target > Embedded Frameworks
 
 
 ## ❌ DEPENDENCIES > "Project" target > Linked Dependencies

--- a/CommandTests/Generated/p1_p2_markdown_format_verbose.2.ac528bab.md
+++ b/CommandTests/Generated/p1_p2_markdown_format_verbose.2.ac528bab.md
@@ -12,7 +12,7 @@
 ## ❌ FILE_REFERENCES
 
 
-### ⚠️  Only in first (7):
+### ⚠️  Only in first (8):
 
   - `Project/Group B/AViewController.xib`
   - `Project/Group B/AnotherObjcClass.h`
@@ -21,10 +21,13 @@
   - `ProjectTests/BarTests.swift`
   - `ProjectUITests/LoginTests.swift`
   - `ProjectUITests/Screenshots/empty.png`
+  - `libMismatchingLibrary.a`
 
 
-### ⚠️  Only in second (9):
+### ⚠️  Only in second (11):
 
+  - `MismatchingLibrary.framework`
+  - `MismatchingLibrary/MismatchingLibrary-Info.plist`
   - `NewFramework.framework`
   - `NewFramework/Info.plist`
   - `NewFramework/NewFramework.h`
@@ -45,6 +48,13 @@
   - `NewFramework`
 
 
+### ⚠️  Value mismatch (1):
+
+  - `MismatchingLibrary product type`
+    - `com.apple.product-type.library.static`
+    - `com.apple.product-type.framework`
+
+
 
 ## ❌ TARGETS > AGGREGATE targets
 
@@ -52,6 +62,15 @@
 ### ⚠️  Only in second (1):
 
   - `NewAggregate`
+
+
+
+## ❌ HEADERS > "MismatchingLibrary" target
+
+
+### ⚠️  Only in second (1):
+
+  - `MismatchingLibrary/MismatchingLibrary.h`
 
 
 
@@ -82,6 +101,9 @@
 
 
 ## ✅ HEADERS > "ProjectUITests" target
+
+
+## ✅ SOURCES > "MismatchingLibrary" target
 
 
 ## ❌ SOURCES > "Project" target
@@ -124,6 +146,9 @@
 
   - `ProjectUITests/MetricsTests.swift`
 
+
+
+## ✅ RESOURCES > "MismatchingLibrary" target
 
 
 ## ❌ RESOURCES > "Project" target
@@ -198,6 +223,77 @@
 
 
 
+## ✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
+
+
+## ❌ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Values
+
+
+### ⚠️  Only in first (1):
+
+  - `OTHER_LDFLAGS`
+
+
+### ⚠️  Only in second (13):
+
+  - `CLANG_ENABLE_MODULES`
+  - `CURRENT_PROJECT_VERSION`
+  - `DEFINES_MODULE`
+  - `DYLIB_COMPATIBILITY_VERSION`
+  - `DYLIB_CURRENT_VERSION`
+  - `DYLIB_INSTALL_NAME_BASE`
+  - `INFOPLIST_FILE`
+  - `INSTALL_PATH`
+  - `LD_RUNPATH_SEARCH_PATHS`
+  - `PRODUCT_BUNDLE_IDENTIFIER`
+  - `SWIFT_OPTIMIZATION_LEVEL`
+  - `VERSIONING_SYSTEM`
+  - `VERSION_INFO_PREFIX`
+
+
+### ⚠️  Value mismatch (1):
+
+  - `PRODUCT_NAME`
+    - `$(TARGET_NAME)`
+    - `$(TARGET_NAME:c99extidentifier)`
+
+
+
+## ✅ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Base configuration
+
+
+## ❌ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Values
+
+
+### ⚠️  Only in first (1):
+
+  - `OTHER_LDFLAGS`
+
+
+### ⚠️  Only in second (12):
+
+  - `CLANG_ENABLE_MODULES`
+  - `CURRENT_PROJECT_VERSION`
+  - `DEFINES_MODULE`
+  - `DYLIB_COMPATIBILITY_VERSION`
+  - `DYLIB_CURRENT_VERSION`
+  - `DYLIB_INSTALL_NAME_BASE`
+  - `INFOPLIST_FILE`
+  - `INSTALL_PATH`
+  - `LD_RUNPATH_SEARCH_PATHS`
+  - `PRODUCT_BUNDLE_IDENTIFIER`
+  - `VERSIONING_SYSTEM`
+  - `VERSION_INFO_PREFIX`
+
+
+### ⚠️  Value mismatch (1):
+
+  - `PRODUCT_NAME`
+    - `$(TARGET_NAME)`
+    - `$(TARGET_NAME:c99extidentifier)`
+
+
+
 ## ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
 
 
@@ -210,6 +306,11 @@
 
 
 ## ❌ SETTINGS > "Project" target > "Debug" configuration > Values
+
+
+### ⚠️  Only in second (1):
+
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
 
 
 ### ⚠️  Value mismatch (1):
@@ -226,6 +327,11 @@
 ## ❌ SETTINGS > "Project" target > "Release" configuration > Values
 
 
+### ⚠️  Only in second (1):
+
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
+
+
 ### ⚠️  Value mismatch (1):
 
   - `CUSTOM_SETTING_COMMON`
@@ -237,13 +343,29 @@
 ## ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Base configuration
 
 
-## ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+## ❌ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+
+
+### ⚠️  Value mismatch (1):
+
+  - `PRODUCT_BUNDLE_IDENTIFIER`
+    - `com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework`
+    - `com.bloomberg.xcdiff.Project.ProjectFramework`
+
 
 
 ## ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Base configuration
 
 
-## ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+## ❌ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+
+
+### ⚠️  Value mismatch (1):
+
+  - `PRODUCT_BUNDLE_IDENTIFIER`
+    - `com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework`
+    - `com.bloomberg.xcdiff.Project.ProjectFramework`
+
 
 
 ## ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Base configuration
@@ -274,7 +396,7 @@
 
 Output format: (<path>, <name>, <source_tree>)
 
-### ⚠️  Only in first (7):
+### ⚠️  Only in first (8):
 
   - `(AViewController.xib, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
   - `(AnotherObjcClass.h, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
@@ -282,15 +404,18 @@ Output format: (<path>, <name>, <source_tree>)
   - `(BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)`
   - `(LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)`
   - `(empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)`
+  - `(libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)`
   - `(time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
 
 
-### ⚠️  Only in second (9):
+### ⚠️  Only in second (11):
 
   - `(Header4.h, nil, <group>) → (ProjectFramework, nil, <group>) → (nil, nil, <group>)`
   - `(Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)`
   - `(ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)`
   - `(MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)`
+  - `(MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)`
+  - `(MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)`
   - `(NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)`
   - `(NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)`
   - `(Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
@@ -299,11 +424,18 @@ Output format: (<path>, <name>, <source_tree>)
 
 
 
+## ✅ DEPENDENCIES > "MismatchingLibrary" target > Linked Dependencies
+
+
+## ✅ DEPENDENCIES > "MismatchingLibrary" target > Embedded Frameworks
+
+
 ## ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 
 
-### ⚠️  Only in second (1):
+### ⚠️  Only in second (2):
 
+  - `MismatchingLibrary.framework`
   - `NewFramework.framework`
 
 
@@ -318,8 +450,9 @@ Output format: (<path>, <name>, <source_tree>)
 ## ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 
 
-### ⚠️  Only in second (1):
+### ⚠️  Only in second (2):
 
+  - `MismatchingLibrary.framework`
   - `NewFramework.framework`
 
 

--- a/CommandTests/Generated/p1_p2_resources_tag.2.976bfc43.md
+++ b/CommandTests/Generated/p1_p2_resources_tag.2.976bfc43.md
@@ -8,6 +8,7 @@
 
 # Expected output
 ```
+✅ RESOURCES > "MismatchingLibrary" target
 ❌ RESOURCES > "Project" target
 ✅ RESOURCES > "ProjectFramework" target
 ❌ RESOURCES > "ProjectTests" target

--- a/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target.1.d4ececa6.md
+++ b/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target.1.d4ececa6.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target_console_format.1.96130ae0.md
+++ b/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target_console_format.1.96130ae0.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target_console_format_verbose.1.cda4dc90.md
+++ b/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target_console_format_verbose.1.cda4dc90.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target_json_format.1.ad5c5553.md
+++ b/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target_json_format.1.ad5c5553.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target_json_format_verbose.1.09f3af23.md
+++ b/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target_json_format_verbose.1.09f3af23.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target_markdown_format.1.818975a8.md
+++ b/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target_markdown_format.1.818975a8.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target_markdown_format_verbose.1.ff2afe5f.md
+++ b/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target_markdown_format_verbose.1.ff2afe5f.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target_verbose.1.12d6ffec.md
+++ b/CommandTests/Generated/p1_p2_resources_tag_NewFramework_target_verbose.1.12d6ffec.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_resources_tag_console_format.2.c032ef31.md
+++ b/CommandTests/Generated/p1_p2_resources_tag_console_format.2.c032ef31.md
@@ -8,6 +8,7 @@
 
 # Expected output
 ```
+✅ RESOURCES > "MismatchingLibrary" target
 ❌ RESOURCES > "Project" target
 ✅ RESOURCES > "ProjectFramework" target
 ❌ RESOURCES > "ProjectTests" target

--- a/CommandTests/Generated/p1_p2_resources_tag_console_format_verbose.2.1cd00005.md
+++ b/CommandTests/Generated/p1_p2_resources_tag_console_format_verbose.2.1cd00005.md
@@ -8,6 +8,7 @@
 
 # Expected output
 ```
+✅ RESOURCES > "MismatchingLibrary" target
 ❌ RESOURCES > "Project" target
 
 ⚠️  Only in first (2):

--- a/CommandTests/Generated/p1_p2_resources_tag_json_format.2.5455f8f9.md
+++ b/CommandTests/Generated/p1_p2_resources_tag_json_format.2.5455f8f9.md
@@ -11,6 +11,21 @@
 [
   {
     "context" : [
+      "\"MismatchingLibrary\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "resources"
+  },
+  {
+    "context" : [
       "\"Project\" target"
     ],
     "differentValues" : [

--- a/CommandTests/Generated/p1_p2_resources_tag_json_format_verbose.2.1d8962a4.md
+++ b/CommandTests/Generated/p1_p2_resources_tag_json_format_verbose.2.1d8962a4.md
@@ -11,6 +11,21 @@
 [
   {
     "context" : [
+      "\"MismatchingLibrary\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "resources"
+  },
+  {
+    "context" : [
       "\"Project\" target"
     ],
     "differentValues" : [

--- a/CommandTests/Generated/p1_p2_resources_tag_markdown_format.2.93973806.md
+++ b/CommandTests/Generated/p1_p2_resources_tag_markdown_format.2.93973806.md
@@ -9,6 +9,9 @@
 # Expected output
 ```
 
+## ✅ RESOURCES > "MismatchingLibrary" target
+
+
 ## ❌ RESOURCES > "Project" target
 
 

--- a/CommandTests/Generated/p1_p2_resources_tag_markdown_format_verbose.2.9073cfbf.md
+++ b/CommandTests/Generated/p1_p2_resources_tag_markdown_format_verbose.2.9073cfbf.md
@@ -9,6 +9,9 @@
 # Expected output
 ```
 
+## ✅ RESOURCES > "MismatchingLibrary" target
+
+
 ## ❌ RESOURCES > "Project" target
 
 

--- a/CommandTests/Generated/p1_p2_resources_tag_verbose.2.be954909.md
+++ b/CommandTests/Generated/p1_p2_resources_tag_verbose.2.be954909.md
@@ -8,6 +8,7 @@
 
 # Expected output
 ```
+✅ RESOURCES > "MismatchingLibrary" target
 ❌ RESOURCES > "Project" target
 
 ⚠️  Only in first (2):

--- a/CommandTests/Generated/p1_p2_settings_tag.2.f2fd961e.md
+++ b/CommandTests/Generated/p1_p2_settings_tag.2.f2fd961e.md
@@ -12,14 +12,18 @@
 ❌ SETTINGS > Root project > "Debug" configuration > Values
 ✅ SETTINGS > Root project > "Release" configuration > Base configuration
 ❌ SETTINGS > Root project > "Release" configuration > Values
+✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Values
+✅ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Values
 ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Debug" configuration > Values
 ✅ SETTINGS > "Project" target > "Release" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Release" configuration > Values
 ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
 ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Base configuration
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Values
 ✅ SETTINGS > "ProjectTests" target > "Release" configuration > Base configuration

--- a/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target.1.29612643.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target.1.29612643.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target_console_format.1.81be3a1b.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target_console_format.1.81be3a1b.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target_console_format_verbose.1.aed53032.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target_console_format_verbose.1.aed53032.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target_json_format.1.af55ee12.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target_json_format.1.af55ee12.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target_json_format_verbose.1.08beb39e.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target_json_format_verbose.1.08beb39e.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target_markdown_format.1.86d189f7.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target_markdown_format.1.86d189f7.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target_markdown_format_verbose.1.c8eec25c.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target_markdown_format_verbose.1.c8eec25c.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target_verbose.1.e80ef86b.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_NewFramework_target_verbose.1.e80ef86b.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_settings_tag_Project_target_console_format_verbose.2.60fa85f8.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_Project_target_console_format_verbose.2.60fa85f8.md
@@ -43,6 +43,11 @@
 
 ❌ SETTINGS > "Project" target > "Debug" configuration > Values
 
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
+
 ⚠️  Value mismatch (1):
 
   • CUSTOM_SETTING_COMMON
@@ -52,6 +57,11 @@
 
 ✅ SETTINGS > "Project" target > "Release" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Release" configuration > Values
+
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
 
 ⚠️  Value mismatch (1):
 

--- a/CommandTests/Generated/p1_p2_settings_tag_Project_target_json_format.2.63c69b62.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_Project_target_json_format.2.63c69b62.md
@@ -119,7 +119,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   },
@@ -157,7 +157,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   }

--- a/CommandTests/Generated/p1_p2_settings_tag_Project_target_json_format_verbose.2.59e64a35.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_Project_target_json_format_verbose.2.59e64a35.md
@@ -119,7 +119,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   },
@@ -157,7 +157,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   }

--- a/CommandTests/Generated/p1_p2_settings_tag_Project_target_markdown_format_verbose.2.7eb42f94.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_Project_target_markdown_format_verbose.2.7eb42f94.md
@@ -55,6 +55,11 @@
 ## ❌ SETTINGS > "Project" target > "Debug" configuration > Values
 
 
+### ⚠️  Only in second (1):
+
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
+
+
 ### ⚠️  Value mismatch (1):
 
   - `CUSTOM_SETTING_COMMON`
@@ -67,6 +72,11 @@
 
 
 ## ❌ SETTINGS > "Project" target > "Release" configuration > Values
+
+
+### ⚠️  Only in second (1):
+
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
 
 
 ### ⚠️  Value mismatch (1):

--- a/CommandTests/Generated/p1_p2_settings_tag_Project_target_verbose.2.23efff72.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_Project_target_verbose.2.23efff72.md
@@ -43,6 +43,11 @@
 
 ❌ SETTINGS > "Project" target > "Debug" configuration > Values
 
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
+
 ⚠️  Value mismatch (1):
 
   • CUSTOM_SETTING_COMMON
@@ -52,6 +57,11 @@
 
 ✅ SETTINGS > "Project" target > "Release" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Release" configuration > Values
+
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
 
 ⚠️  Value mismatch (1):
 

--- a/CommandTests/Generated/p1_p2_settings_tag_console_format.2.c4a723fc.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_console_format.2.c4a723fc.md
@@ -12,14 +12,18 @@
 ❌ SETTINGS > Root project > "Debug" configuration > Values
 ✅ SETTINGS > Root project > "Release" configuration > Base configuration
 ❌ SETTINGS > Root project > "Release" configuration > Values
+✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Values
+✅ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Values
 ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Debug" configuration > Values
 ✅ SETTINGS > "Project" target > "Release" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Release" configuration > Values
 ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
 ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Base configuration
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Values
 ✅ SETTINGS > "ProjectTests" target > "Release" configuration > Base configuration

--- a/CommandTests/Generated/p1_p2_settings_tag_console_format_verbose.2.6dad29ce.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_console_format_verbose.2.6dad29ce.md
@@ -32,6 +32,69 @@
   • CUSTOM_SETTGING_1
 
 
+✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Values
+
+⚠️  Only in first (1):
+
+  • OTHER_LDFLAGS
+
+
+⚠️  Only in second (13):
+
+  • CLANG_ENABLE_MODULES
+  • CURRENT_PROJECT_VERSION
+  • DEFINES_MODULE
+  • DYLIB_COMPATIBILITY_VERSION
+  • DYLIB_CURRENT_VERSION
+  • DYLIB_INSTALL_NAME_BASE
+  • INFOPLIST_FILE
+  • INSTALL_PATH
+  • LD_RUNPATH_SEARCH_PATHS
+  • PRODUCT_BUNDLE_IDENTIFIER
+  • SWIFT_OPTIMIZATION_LEVEL
+  • VERSIONING_SYSTEM
+  • VERSION_INFO_PREFIX
+
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_NAME
+    ◦ $(TARGET_NAME)
+    ◦ $(TARGET_NAME:c99extidentifier)
+
+
+✅ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Values
+
+⚠️  Only in first (1):
+
+  • OTHER_LDFLAGS
+
+
+⚠️  Only in second (12):
+
+  • CLANG_ENABLE_MODULES
+  • CURRENT_PROJECT_VERSION
+  • DEFINES_MODULE
+  • DYLIB_COMPATIBILITY_VERSION
+  • DYLIB_CURRENT_VERSION
+  • DYLIB_INSTALL_NAME_BASE
+  • INFOPLIST_FILE
+  • INSTALL_PATH
+  • LD_RUNPATH_SEARCH_PATHS
+  • PRODUCT_BUNDLE_IDENTIFIER
+  • VERSIONING_SYSTEM
+  • VERSION_INFO_PREFIX
+
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_NAME
+    ◦ $(TARGET_NAME)
+    ◦ $(TARGET_NAME:c99extidentifier)
+
+
 ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
 
 ⚠️  Value mismatch (1):
@@ -43,6 +106,11 @@
 
 ❌ SETTINGS > "Project" target > "Debug" configuration > Values
 
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
+
 ⚠️  Value mismatch (1):
 
   • CUSTOM_SETTING_COMMON
@@ -53,6 +121,11 @@
 ✅ SETTINGS > "Project" target > "Release" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Release" configuration > Values
 
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
+
 ⚠️  Value mismatch (1):
 
   • CUSTOM_SETTING_COMMON
@@ -61,9 +134,25 @@
 
 
 ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_BUNDLE_IDENTIFIER
+    ◦ com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework
+    ◦ com.bloomberg.xcdiff.Project.ProjectFramework
+
+
 ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_BUNDLE_IDENTIFIER
+    ◦ com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework
+    ◦ com.bloomberg.xcdiff.Project.ProjectFramework
+
+
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Base configuration
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Values
 ✅ SETTINGS > "ProjectTests" target > "Release" configuration > Base configuration

--- a/CommandTests/Generated/p1_p2_settings_tag_json_format.2.c77fc477.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_json_format.2.c77fc477.md
@@ -83,6 +83,105 @@
   },
   {
     "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Debug\" configuration",
+      "Base configuration"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Debug\" configuration",
+      "Values"
+    ],
+    "differentValues" : [
+      {
+        "context" : "PRODUCT_NAME",
+        "first" : "$(TARGET_NAME)",
+        "second" : "$(TARGET_NAME:c99extidentifier)"
+      }
+    ],
+    "onlyInFirst" : [
+      "OTHER_LDFLAGS"
+    ],
+    "onlyInSecond" : [
+      "CLANG_ENABLE_MODULES",
+      "CURRENT_PROJECT_VERSION",
+      "DEFINES_MODULE",
+      "DYLIB_COMPATIBILITY_VERSION",
+      "DYLIB_CURRENT_VERSION",
+      "DYLIB_INSTALL_NAME_BASE",
+      "INFOPLIST_FILE",
+      "INSTALL_PATH",
+      "LD_RUNPATH_SEARCH_PATHS",
+      "PRODUCT_BUNDLE_IDENTIFIER",
+      "SWIFT_OPTIMIZATION_LEVEL",
+      "VERSIONING_SYSTEM",
+      "VERSION_INFO_PREFIX"
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Release\" configuration",
+      "Base configuration"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Release\" configuration",
+      "Values"
+    ],
+    "differentValues" : [
+      {
+        "context" : "PRODUCT_NAME",
+        "first" : "$(TARGET_NAME)",
+        "second" : "$(TARGET_NAME:c99extidentifier)"
+      }
+    ],
+    "onlyInFirst" : [
+      "OTHER_LDFLAGS"
+    ],
+    "onlyInSecond" : [
+      "CLANG_ENABLE_MODULES",
+      "CURRENT_PROJECT_VERSION",
+      "DEFINES_MODULE",
+      "DYLIB_COMPATIBILITY_VERSION",
+      "DYLIB_CURRENT_VERSION",
+      "DYLIB_INSTALL_NAME_BASE",
+      "INFOPLIST_FILE",
+      "INSTALL_PATH",
+      "LD_RUNPATH_SEARCH_PATHS",
+      "PRODUCT_BUNDLE_IDENTIFIER",
+      "VERSIONING_SYSTEM",
+      "VERSION_INFO_PREFIX"
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
       "\"Project\" target",
       "\"Debug\" configuration",
       "Base configuration"
@@ -119,7 +218,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   },
@@ -157,7 +256,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   },
@@ -185,7 +284,11 @@
       "Values"
     ],
     "differentValues" : [
-
+      {
+        "context" : "PRODUCT_BUNDLE_IDENTIFIER",
+        "first" : "com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework",
+        "second" : "com.bloomberg.xcdiff.Project.ProjectFramework"
+      }
     ],
     "onlyInFirst" : [
 
@@ -219,7 +322,11 @@
       "Values"
     ],
     "differentValues" : [
-
+      {
+        "context" : "PRODUCT_BUNDLE_IDENTIFIER",
+        "first" : "com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework",
+        "second" : "com.bloomberg.xcdiff.Project.ProjectFramework"
+      }
     ],
     "onlyInFirst" : [
 

--- a/CommandTests/Generated/p1_p2_settings_tag_json_format_verbose.2.bd3b2234.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_json_format_verbose.2.bd3b2234.md
@@ -83,6 +83,105 @@
   },
   {
     "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Debug\" configuration",
+      "Base configuration"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Debug\" configuration",
+      "Values"
+    ],
+    "differentValues" : [
+      {
+        "context" : "PRODUCT_NAME",
+        "first" : "$(TARGET_NAME)",
+        "second" : "$(TARGET_NAME:c99extidentifier)"
+      }
+    ],
+    "onlyInFirst" : [
+      "OTHER_LDFLAGS"
+    ],
+    "onlyInSecond" : [
+      "CLANG_ENABLE_MODULES",
+      "CURRENT_PROJECT_VERSION",
+      "DEFINES_MODULE",
+      "DYLIB_COMPATIBILITY_VERSION",
+      "DYLIB_CURRENT_VERSION",
+      "DYLIB_INSTALL_NAME_BASE",
+      "INFOPLIST_FILE",
+      "INSTALL_PATH",
+      "LD_RUNPATH_SEARCH_PATHS",
+      "PRODUCT_BUNDLE_IDENTIFIER",
+      "SWIFT_OPTIMIZATION_LEVEL",
+      "VERSIONING_SYSTEM",
+      "VERSION_INFO_PREFIX"
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Release\" configuration",
+      "Base configuration"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
+      "\"MismatchingLibrary\" target",
+      "\"Release\" configuration",
+      "Values"
+    ],
+    "differentValues" : [
+      {
+        "context" : "PRODUCT_NAME",
+        "first" : "$(TARGET_NAME)",
+        "second" : "$(TARGET_NAME:c99extidentifier)"
+      }
+    ],
+    "onlyInFirst" : [
+      "OTHER_LDFLAGS"
+    ],
+    "onlyInSecond" : [
+      "CLANG_ENABLE_MODULES",
+      "CURRENT_PROJECT_VERSION",
+      "DEFINES_MODULE",
+      "DYLIB_COMPATIBILITY_VERSION",
+      "DYLIB_CURRENT_VERSION",
+      "DYLIB_INSTALL_NAME_BASE",
+      "INFOPLIST_FILE",
+      "INSTALL_PATH",
+      "LD_RUNPATH_SEARCH_PATHS",
+      "PRODUCT_BUNDLE_IDENTIFIER",
+      "VERSIONING_SYSTEM",
+      "VERSION_INFO_PREFIX"
+    ],
+    "tag" : "settings"
+  },
+  {
+    "context" : [
       "\"Project\" target",
       "\"Debug\" configuration",
       "Base configuration"
@@ -119,7 +218,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   },
@@ -157,7 +256,7 @@
 
     ],
     "onlyInSecond" : [
-
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
     ],
     "tag" : "settings"
   },
@@ -185,7 +284,11 @@
       "Values"
     ],
     "differentValues" : [
-
+      {
+        "context" : "PRODUCT_BUNDLE_IDENTIFIER",
+        "first" : "com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework",
+        "second" : "com.bloomberg.xcdiff.Project.ProjectFramework"
+      }
     ],
     "onlyInFirst" : [
 
@@ -219,7 +322,11 @@
       "Values"
     ],
     "differentValues" : [
-
+      {
+        "context" : "PRODUCT_BUNDLE_IDENTIFIER",
+        "first" : "com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework",
+        "second" : "com.bloomberg.xcdiff.Project.ProjectFramework"
+      }
     ],
     "onlyInFirst" : [
 

--- a/CommandTests/Generated/p1_p2_settings_tag_markdown_format.2.5b0d2427.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_markdown_format.2.5b0d2427.md
@@ -21,6 +21,18 @@
 ## ❌ SETTINGS > Root project > "Release" configuration > Values
 
 
+## ✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
+
+
+## ❌ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Values
+
+
+## ✅ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Base configuration
+
+
+## ❌ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Values
+
+
 ## ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
 
 
@@ -36,13 +48,13 @@
 ## ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Base configuration
 
 
-## ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+## ❌ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
 
 
 ## ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Base configuration
 
 
-## ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+## ❌ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
 
 
 ## ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Base configuration

--- a/CommandTests/Generated/p1_p2_settings_tag_markdown_format_verbose.2.ed874e8d.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_markdown_format_verbose.2.ed874e8d.md
@@ -41,6 +41,77 @@
 
 
 
+## ✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
+
+
+## ❌ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Values
+
+
+### ⚠️  Only in first (1):
+
+  - `OTHER_LDFLAGS`
+
+
+### ⚠️  Only in second (13):
+
+  - `CLANG_ENABLE_MODULES`
+  - `CURRENT_PROJECT_VERSION`
+  - `DEFINES_MODULE`
+  - `DYLIB_COMPATIBILITY_VERSION`
+  - `DYLIB_CURRENT_VERSION`
+  - `DYLIB_INSTALL_NAME_BASE`
+  - `INFOPLIST_FILE`
+  - `INSTALL_PATH`
+  - `LD_RUNPATH_SEARCH_PATHS`
+  - `PRODUCT_BUNDLE_IDENTIFIER`
+  - `SWIFT_OPTIMIZATION_LEVEL`
+  - `VERSIONING_SYSTEM`
+  - `VERSION_INFO_PREFIX`
+
+
+### ⚠️  Value mismatch (1):
+
+  - `PRODUCT_NAME`
+    - `$(TARGET_NAME)`
+    - `$(TARGET_NAME:c99extidentifier)`
+
+
+
+## ✅ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Base configuration
+
+
+## ❌ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Values
+
+
+### ⚠️  Only in first (1):
+
+  - `OTHER_LDFLAGS`
+
+
+### ⚠️  Only in second (12):
+
+  - `CLANG_ENABLE_MODULES`
+  - `CURRENT_PROJECT_VERSION`
+  - `DEFINES_MODULE`
+  - `DYLIB_COMPATIBILITY_VERSION`
+  - `DYLIB_CURRENT_VERSION`
+  - `DYLIB_INSTALL_NAME_BASE`
+  - `INFOPLIST_FILE`
+  - `INSTALL_PATH`
+  - `LD_RUNPATH_SEARCH_PATHS`
+  - `PRODUCT_BUNDLE_IDENTIFIER`
+  - `VERSIONING_SYSTEM`
+  - `VERSION_INFO_PREFIX`
+
+
+### ⚠️  Value mismatch (1):
+
+  - `PRODUCT_NAME`
+    - `$(TARGET_NAME)`
+    - `$(TARGET_NAME:c99extidentifier)`
+
+
+
 ## ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
 
 
@@ -53,6 +124,11 @@
 
 
 ## ❌ SETTINGS > "Project" target > "Debug" configuration > Values
+
+
+### ⚠️  Only in second (1):
+
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
 
 
 ### ⚠️  Value mismatch (1):
@@ -69,6 +145,11 @@
 ## ❌ SETTINGS > "Project" target > "Release" configuration > Values
 
 
+### ⚠️  Only in second (1):
+
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
+
+
 ### ⚠️  Value mismatch (1):
 
   - `CUSTOM_SETTING_COMMON`
@@ -80,13 +161,29 @@
 ## ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Base configuration
 
 
-## ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+## ❌ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+
+
+### ⚠️  Value mismatch (1):
+
+  - `PRODUCT_BUNDLE_IDENTIFIER`
+    - `com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework`
+    - `com.bloomberg.xcdiff.Project.ProjectFramework`
+
 
 
 ## ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Base configuration
 
 
-## ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+## ❌ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+
+
+### ⚠️  Value mismatch (1):
+
+  - `PRODUCT_BUNDLE_IDENTIFIER`
+    - `com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework`
+    - `com.bloomberg.xcdiff.Project.ProjectFramework`
+
 
 
 ## ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Base configuration

--- a/CommandTests/Generated/p1_p2_settings_tag_verbose.2.97d9bb79.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_verbose.2.97d9bb79.md
@@ -32,6 +32,69 @@
   • CUSTOM_SETTGING_1
 
 
+✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Values
+
+⚠️  Only in first (1):
+
+  • OTHER_LDFLAGS
+
+
+⚠️  Only in second (13):
+
+  • CLANG_ENABLE_MODULES
+  • CURRENT_PROJECT_VERSION
+  • DEFINES_MODULE
+  • DYLIB_COMPATIBILITY_VERSION
+  • DYLIB_CURRENT_VERSION
+  • DYLIB_INSTALL_NAME_BASE
+  • INFOPLIST_FILE
+  • INSTALL_PATH
+  • LD_RUNPATH_SEARCH_PATHS
+  • PRODUCT_BUNDLE_IDENTIFIER
+  • SWIFT_OPTIMIZATION_LEVEL
+  • VERSIONING_SYSTEM
+  • VERSION_INFO_PREFIX
+
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_NAME
+    ◦ $(TARGET_NAME)
+    ◦ $(TARGET_NAME:c99extidentifier)
+
+
+✅ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Values
+
+⚠️  Only in first (1):
+
+  • OTHER_LDFLAGS
+
+
+⚠️  Only in second (12):
+
+  • CLANG_ENABLE_MODULES
+  • CURRENT_PROJECT_VERSION
+  • DEFINES_MODULE
+  • DYLIB_COMPATIBILITY_VERSION
+  • DYLIB_CURRENT_VERSION
+  • DYLIB_INSTALL_NAME_BASE
+  • INFOPLIST_FILE
+  • INSTALL_PATH
+  • LD_RUNPATH_SEARCH_PATHS
+  • PRODUCT_BUNDLE_IDENTIFIER
+  • VERSIONING_SYSTEM
+  • VERSION_INFO_PREFIX
+
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_NAME
+    ◦ $(TARGET_NAME)
+    ◦ $(TARGET_NAME:c99extidentifier)
+
+
 ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
 
 ⚠️  Value mismatch (1):
@@ -43,6 +106,11 @@
 
 ❌ SETTINGS > "Project" target > "Debug" configuration > Values
 
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
+
 ⚠️  Value mismatch (1):
 
   • CUSTOM_SETTING_COMMON
@@ -53,6 +121,11 @@
 ✅ SETTINGS > "Project" target > "Release" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Release" configuration > Values
 
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
+
 ⚠️  Value mismatch (1):
 
   • CUSTOM_SETTING_COMMON
@@ -61,9 +134,25 @@
 
 
 ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_BUNDLE_IDENTIFIER
+    ◦ com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework
+    ◦ com.bloomberg.xcdiff.Project.ProjectFramework
+
+
 ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_BUNDLE_IDENTIFIER
+    ◦ com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework
+    ◦ com.bloomberg.xcdiff.Project.ProjectFramework
+
+
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Base configuration
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Values
 ✅ SETTINGS > "ProjectTests" target > "Release" configuration > Base configuration

--- a/CommandTests/Generated/p1_p2_source_trees_tag_NewFramework_target_console_format_verbose.2.26b0d49b.md
+++ b/CommandTests/Generated/p1_p2_source_trees_tag_NewFramework_target_console_format_verbose.2.26b0d49b.md
@@ -11,7 +11,7 @@
 ❌ SOURCE_TREES > Root project
 Output format: (<path>, <name>, <source_tree>)
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • (AViewController.xib, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
   • (AnotherObjcClass.h, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
@@ -19,15 +19,18 @@ Output format: (<path>, <name>, <source_tree>)
   • (BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
   • (empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
   • (Header4.h, nil, <group>) → (ProjectFramework, nil, <group>) → (nil, nil, <group>)
   • (Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)

--- a/CommandTests/Generated/p1_p2_source_trees_tag_NewFramework_target_json_format.2.6b570f2f.md
+++ b/CommandTests/Generated/p1_p2_source_trees_tag_NewFramework_target_json_format.2.6b570f2f.md
@@ -24,6 +24,7 @@
       "(BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
       "(empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)"
     ],
     "onlyInSecond" : [
@@ -31,6 +32,8 @@
       "(Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)",

--- a/CommandTests/Generated/p1_p2_source_trees_tag_NewFramework_target_json_format_verbose.2.a8aef9ec.md
+++ b/CommandTests/Generated/p1_p2_source_trees_tag_NewFramework_target_json_format_verbose.2.a8aef9ec.md
@@ -24,6 +24,7 @@
       "(BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
       "(empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)"
     ],
     "onlyInSecond" : [
@@ -31,6 +32,8 @@
       "(Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)",

--- a/CommandTests/Generated/p1_p2_source_trees_tag_NewFramework_target_markdown_format_verbose.2.78ec639f.md
+++ b/CommandTests/Generated/p1_p2_source_trees_tag_NewFramework_target_markdown_format_verbose.2.78ec639f.md
@@ -13,7 +13,7 @@
 
 Output format: (<path>, <name>, <source_tree>)
 
-### ⚠️  Only in first (7):
+### ⚠️  Only in first (8):
 
   - `(AViewController.xib, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
   - `(AnotherObjcClass.h, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
@@ -21,15 +21,18 @@ Output format: (<path>, <name>, <source_tree>)
   - `(BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)`
   - `(LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)`
   - `(empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)`
+  - `(libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)`
   - `(time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
 
 
-### ⚠️  Only in second (9):
+### ⚠️  Only in second (11):
 
   - `(Header4.h, nil, <group>) → (ProjectFramework, nil, <group>) → (nil, nil, <group>)`
   - `(Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)`
   - `(ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)`
   - `(MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)`
+  - `(MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)`
+  - `(MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)`
   - `(NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)`
   - `(NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)`
   - `(Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`

--- a/CommandTests/Generated/p1_p2_source_trees_tag_NewFramework_target_verbose.2.2e379ade.md
+++ b/CommandTests/Generated/p1_p2_source_trees_tag_NewFramework_target_verbose.2.2e379ade.md
@@ -11,7 +11,7 @@
 ❌ SOURCE_TREES > Root project
 Output format: (<path>, <name>, <source_tree>)
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • (AViewController.xib, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
   • (AnotherObjcClass.h, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
@@ -19,15 +19,18 @@ Output format: (<path>, <name>, <source_tree>)
   • (BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
   • (empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
   • (Header4.h, nil, <group>) → (ProjectFramework, nil, <group>) → (nil, nil, <group>)
   • (Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)

--- a/CommandTests/Generated/p1_p2_source_trees_tag_Project_target_console_format_verbose.2.418aec5f.md
+++ b/CommandTests/Generated/p1_p2_source_trees_tag_Project_target_console_format_verbose.2.418aec5f.md
@@ -11,7 +11,7 @@
 ❌ SOURCE_TREES > Root project
 Output format: (<path>, <name>, <source_tree>)
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • (AViewController.xib, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
   • (AnotherObjcClass.h, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
@@ -19,15 +19,18 @@ Output format: (<path>, <name>, <source_tree>)
   • (BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
   • (empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
   • (Header4.h, nil, <group>) → (ProjectFramework, nil, <group>) → (nil, nil, <group>)
   • (Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)

--- a/CommandTests/Generated/p1_p2_source_trees_tag_Project_target_json_format.2.fe775d76.md
+++ b/CommandTests/Generated/p1_p2_source_trees_tag_Project_target_json_format.2.fe775d76.md
@@ -24,6 +24,7 @@
       "(BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
       "(empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)"
     ],
     "onlyInSecond" : [
@@ -31,6 +32,8 @@
       "(Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)",

--- a/CommandTests/Generated/p1_p2_source_trees_tag_Project_target_json_format_verbose.2.4dd81bf1.md
+++ b/CommandTests/Generated/p1_p2_source_trees_tag_Project_target_json_format_verbose.2.4dd81bf1.md
@@ -24,6 +24,7 @@
       "(BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
       "(empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)"
     ],
     "onlyInSecond" : [
@@ -31,6 +32,8 @@
       "(Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)",

--- a/CommandTests/Generated/p1_p2_source_trees_tag_Project_target_markdown_format_verbose.2.d0b04aa8.md
+++ b/CommandTests/Generated/p1_p2_source_trees_tag_Project_target_markdown_format_verbose.2.d0b04aa8.md
@@ -13,7 +13,7 @@
 
 Output format: (<path>, <name>, <source_tree>)
 
-### ⚠️  Only in first (7):
+### ⚠️  Only in first (8):
 
   - `(AViewController.xib, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
   - `(AnotherObjcClass.h, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
@@ -21,15 +21,18 @@ Output format: (<path>, <name>, <source_tree>)
   - `(BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)`
   - `(LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)`
   - `(empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)`
+  - `(libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)`
   - `(time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
 
 
-### ⚠️  Only in second (9):
+### ⚠️  Only in second (11):
 
   - `(Header4.h, nil, <group>) → (ProjectFramework, nil, <group>) → (nil, nil, <group>)`
   - `(Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)`
   - `(ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)`
   - `(MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)`
+  - `(MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)`
+  - `(MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)`
   - `(NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)`
   - `(NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)`
   - `(Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`

--- a/CommandTests/Generated/p1_p2_source_trees_tag_Project_target_verbose.2.177bfbb4.md
+++ b/CommandTests/Generated/p1_p2_source_trees_tag_Project_target_verbose.2.177bfbb4.md
@@ -11,7 +11,7 @@
 ❌ SOURCE_TREES > Root project
 Output format: (<path>, <name>, <source_tree>)
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • (AViewController.xib, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
   • (AnotherObjcClass.h, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
@@ -19,15 +19,18 @@ Output format: (<path>, <name>, <source_tree>)
   • (BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
   • (empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
   • (Header4.h, nil, <group>) → (ProjectFramework, nil, <group>) → (nil, nil, <group>)
   • (Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)

--- a/CommandTests/Generated/p1_p2_source_trees_tag_console_format_verbose.2.f89817a0.md
+++ b/CommandTests/Generated/p1_p2_source_trees_tag_console_format_verbose.2.f89817a0.md
@@ -11,7 +11,7 @@
 ❌ SOURCE_TREES > Root project
 Output format: (<path>, <name>, <source_tree>)
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • (AViewController.xib, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
   • (AnotherObjcClass.h, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
@@ -19,15 +19,18 @@ Output format: (<path>, <name>, <source_tree>)
   • (BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
   • (empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
   • (Header4.h, nil, <group>) → (ProjectFramework, nil, <group>) → (nil, nil, <group>)
   • (Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)

--- a/CommandTests/Generated/p1_p2_source_trees_tag_json_format.2.8eb396e0.md
+++ b/CommandTests/Generated/p1_p2_source_trees_tag_json_format.2.8eb396e0.md
@@ -24,6 +24,7 @@
       "(BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
       "(empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)"
     ],
     "onlyInSecond" : [
@@ -31,6 +32,8 @@
       "(Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)",

--- a/CommandTests/Generated/p1_p2_source_trees_tag_json_format_verbose.2.2b8177fb.md
+++ b/CommandTests/Generated/p1_p2_source_trees_tag_json_format_verbose.2.2b8177fb.md
@@ -24,6 +24,7 @@
       "(BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
       "(empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)"
     ],
     "onlyInSecond" : [
@@ -31,6 +32,8 @@
       "(Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)",
       "(MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)",
+      "(MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)",
       "(NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)",
       "(Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)",

--- a/CommandTests/Generated/p1_p2_source_trees_tag_markdown_format_verbose.2.94810d60.md
+++ b/CommandTests/Generated/p1_p2_source_trees_tag_markdown_format_verbose.2.94810d60.md
@@ -13,7 +13,7 @@
 
 Output format: (<path>, <name>, <source_tree>)
 
-### ⚠️  Only in first (7):
+### ⚠️  Only in first (8):
 
   - `(AViewController.xib, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
   - `(AnotherObjcClass.h, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
@@ -21,15 +21,18 @@ Output format: (<path>, <name>, <source_tree>)
   - `(BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)`
   - `(LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)`
   - `(empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)`
+  - `(libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)`
   - `(time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`
 
 
-### ⚠️  Only in second (9):
+### ⚠️  Only in second (11):
 
   - `(Header4.h, nil, <group>) → (ProjectFramework, nil, <group>) → (nil, nil, <group>)`
   - `(Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)`
   - `(ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)`
   - `(MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)`
+  - `(MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)`
+  - `(MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)`
   - `(NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)`
   - `(NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)`
   - `(Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)`

--- a/CommandTests/Generated/p1_p2_source_trees_tag_verbose.2.7a2b0ac2.md
+++ b/CommandTests/Generated/p1_p2_source_trees_tag_verbose.2.7a2b0ac2.md
@@ -11,7 +11,7 @@
 ❌ SOURCE_TREES > Root project
 Output format: (<path>, <name>, <source_tree>)
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • (AViewController.xib, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
   • (AnotherObjcClass.h, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
@@ -19,15 +19,18 @@ Output format: (<path>, <name>, <source_tree>)
   • (BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
   • (empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
   • (Header4.h, nil, <group>) → (ProjectFramework, nil, <group>) → (nil, nil, <group>)
   • (Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)

--- a/CommandTests/Generated/p1_p2_sources_tag.2.8bedb64d.md
+++ b/CommandTests/Generated/p1_p2_sources_tag.2.8bedb64d.md
@@ -8,6 +8,7 @@
 
 # Expected output
 ```
+✅ SOURCES > "MismatchingLibrary" target
 ❌ SOURCES > "Project" target
 ✅ SOURCES > "ProjectFramework" target
 ❌ SOURCES > "ProjectTests" target

--- a/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target.1.ef53f387.md
+++ b/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target.1.ef53f387.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target_console_format.1.64e60fbf.md
+++ b/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target_console_format.1.64e60fbf.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target_console_format_verbose.1.7dfa5455.md
+++ b/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target_console_format_verbose.1.7dfa5455.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target_json_format.1.ac469878.md
+++ b/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target_json_format.1.ac469878.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target_json_format_verbose.1.4283bcac.md
+++ b/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target_json_format_verbose.1.4283bcac.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target_markdown_format.1.6aa6cc2d.md
+++ b/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target_markdown_format.1.6aa6cc2d.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target_markdown_format_verbose.1.2500c898.md
+++ b/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target_markdown_format_verbose.1.2500c898.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target_verbose.1.434ac337.md
+++ b/CommandTests/Generated/p1_p2_sources_tag_NewFramework_target_verbose.1.434ac337.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Generated/p1_p2_sources_tag_console_format.2.827abd8f.md
+++ b/CommandTests/Generated/p1_p2_sources_tag_console_format.2.827abd8f.md
@@ -8,6 +8,7 @@
 
 # Expected output
 ```
+✅ SOURCES > "MismatchingLibrary" target
 ❌ SOURCES > "Project" target
 ✅ SOURCES > "ProjectFramework" target
 ❌ SOURCES > "ProjectTests" target

--- a/CommandTests/Generated/p1_p2_sources_tag_console_format_verbose.2.fb480f7d.md
+++ b/CommandTests/Generated/p1_p2_sources_tag_console_format_verbose.2.fb480f7d.md
@@ -8,6 +8,7 @@
 
 # Expected output
 ```
+✅ SOURCES > "MismatchingLibrary" target
 ❌ SOURCES > "Project" target
 
 ⚠️  Only in first (1):

--- a/CommandTests/Generated/p1_p2_sources_tag_json_format.2.2d3fdaf0.md
+++ b/CommandTests/Generated/p1_p2_sources_tag_json_format.2.2d3fdaf0.md
@@ -11,6 +11,21 @@
 [
   {
     "context" : [
+      "\"MismatchingLibrary\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "sources"
+  },
+  {
+    "context" : [
       "\"Project\" target"
     ],
     "differentValues" : [

--- a/CommandTests/Generated/p1_p2_sources_tag_json_format_verbose.2.62b23e57.md
+++ b/CommandTests/Generated/p1_p2_sources_tag_json_format_verbose.2.62b23e57.md
@@ -11,6 +11,21 @@
 [
   {
     "context" : [
+      "\"MismatchingLibrary\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "sources"
+  },
+  {
+    "context" : [
       "\"Project\" target"
     ],
     "differentValues" : [

--- a/CommandTests/Generated/p1_p2_sources_tag_markdown_format.2.c2c47513.md
+++ b/CommandTests/Generated/p1_p2_sources_tag_markdown_format.2.c2c47513.md
@@ -9,6 +9,9 @@
 # Expected output
 ```
 
+## ✅ SOURCES > "MismatchingLibrary" target
+
+
 ## ❌ SOURCES > "Project" target
 
 

--- a/CommandTests/Generated/p1_p2_sources_tag_markdown_format_verbose.2.7881e7f6.md
+++ b/CommandTests/Generated/p1_p2_sources_tag_markdown_format_verbose.2.7881e7f6.md
@@ -9,6 +9,9 @@
 # Expected output
 ```
 
+## ✅ SOURCES > "MismatchingLibrary" target
+
+
 ## ❌ SOURCES > "Project" target
 
 

--- a/CommandTests/Generated/p1_p2_sources_tag_verbose.2.ea3e88b3.md
+++ b/CommandTests/Generated/p1_p2_sources_tag_verbose.2.ea3e88b3.md
@@ -8,6 +8,7 @@
 
 # Expected output
 ```
+✅ SOURCES > "MismatchingLibrary" target
 ❌ SOURCES > "Project" target
 
 ⚠️  Only in first (1):

--- a/CommandTests/Generated/p1_p2_targets_tag_console_format_verbose.2.66404ebe.md
+++ b/CommandTests/Generated/p1_p2_targets_tag_console_format_verbose.2.66404ebe.md
@@ -15,6 +15,13 @@
   • NewFramework
 
 
+⚠️  Value mismatch (1):
+
+  • MismatchingLibrary product type
+    ◦ com.apple.product-type.library.static
+    ◦ com.apple.product-type.framework
+
+
 ❌ TARGETS > AGGREGATE targets
 
 ⚠️  Only in second (1):

--- a/CommandTests/Generated/p1_p2_targets_tag_json_format.2.cf9b3ff2.md
+++ b/CommandTests/Generated/p1_p2_targets_tag_json_format.2.cf9b3ff2.md
@@ -14,7 +14,11 @@
       "NATIVE targets"
     ],
     "differentValues" : [
-
+      {
+        "context" : "MismatchingLibrary product type",
+        "first" : "com.apple.product-type.library.static",
+        "second" : "com.apple.product-type.framework"
+      }
     ],
     "onlyInFirst" : [
 

--- a/CommandTests/Generated/p1_p2_targets_tag_json_format_verbose.2.839e77c9.md
+++ b/CommandTests/Generated/p1_p2_targets_tag_json_format_verbose.2.839e77c9.md
@@ -14,7 +14,11 @@
       "NATIVE targets"
     ],
     "differentValues" : [
-
+      {
+        "context" : "MismatchingLibrary product type",
+        "first" : "com.apple.product-type.library.static",
+        "second" : "com.apple.product-type.framework"
+      }
     ],
     "onlyInFirst" : [
 

--- a/CommandTests/Generated/p1_p2_targets_tag_markdown_format_verbose.2.21ec7415.md
+++ b/CommandTests/Generated/p1_p2_targets_tag_markdown_format_verbose.2.21ec7415.md
@@ -17,6 +17,13 @@
   - `NewFramework`
 
 
+### ⚠️  Value mismatch (1):
+
+  - `MismatchingLibrary product type`
+    - `com.apple.product-type.library.static`
+    - `com.apple.product-type.framework`
+
+
 
 ## ❌ TARGETS > AGGREGATE targets
 

--- a/CommandTests/Generated/p1_p2_targets_tag_verbose.2.7f724cdf.md
+++ b/CommandTests/Generated/p1_p2_targets_tag_verbose.2.7f724cdf.md
@@ -15,6 +15,13 @@
   • NewFramework
 
 
+⚠️  Value mismatch (1):
+
+  • MismatchingLibrary product type
+    ◦ com.apple.product-type.library.static
+    ◦ com.apple.product-type.framework
+
+
 ❌ TARGETS > AGGREGATE targets
 
 ⚠️  Only in second (1):

--- a/CommandTests/Generated/p1_p2_verbose.2.fe666557.md
+++ b/CommandTests/Generated/p1_p2_verbose.2.fe666557.md
@@ -10,7 +10,7 @@
 ```
 ❌ FILE_REFERENCES
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • Project/Group B/AViewController.xib
   • Project/Group B/AnotherObjcClass.h
@@ -19,10 +19,13 @@
   • ProjectTests/BarTests.swift
   • ProjectUITests/LoginTests.swift
   • ProjectUITests/Screenshots/empty.png
+  • libMismatchingLibrary.a
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
+  • MismatchingLibrary.framework
+  • MismatchingLibrary/MismatchingLibrary-Info.plist
   • NewFramework.framework
   • NewFramework/Info.plist
   • NewFramework/NewFramework.h
@@ -41,11 +44,25 @@
   • NewFramework
 
 
+⚠️  Value mismatch (1):
+
+  • MismatchingLibrary product type
+    ◦ com.apple.product-type.library.static
+    ◦ com.apple.product-type.framework
+
+
 ❌ TARGETS > AGGREGATE targets
 
 ⚠️  Only in second (1):
 
   • NewAggregate
+
+
+❌ HEADERS > "MismatchingLibrary" target
+
+⚠️  Only in second (1):
+
+  • MismatchingLibrary/MismatchingLibrary.h
 
 
 ✅ HEADERS > "Project" target
@@ -69,6 +86,7 @@
 
 ✅ HEADERS > "ProjectTests" target
 ✅ HEADERS > "ProjectUITests" target
+✅ SOURCES > "MismatchingLibrary" target
 ❌ SOURCES > "Project" target
 
 ⚠️  Only in first (1):
@@ -103,6 +121,7 @@
   • ProjectUITests/MetricsTests.swift
 
 
+✅ RESOURCES > "MismatchingLibrary" target
 ❌ RESOURCES > "Project" target
 
 ⚠️  Only in first (2):
@@ -157,6 +176,69 @@
   • CUSTOM_SETTGING_1
 
 
+✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Values
+
+⚠️  Only in first (1):
+
+  • OTHER_LDFLAGS
+
+
+⚠️  Only in second (13):
+
+  • CLANG_ENABLE_MODULES
+  • CURRENT_PROJECT_VERSION
+  • DEFINES_MODULE
+  • DYLIB_COMPATIBILITY_VERSION
+  • DYLIB_CURRENT_VERSION
+  • DYLIB_INSTALL_NAME_BASE
+  • INFOPLIST_FILE
+  • INSTALL_PATH
+  • LD_RUNPATH_SEARCH_PATHS
+  • PRODUCT_BUNDLE_IDENTIFIER
+  • SWIFT_OPTIMIZATION_LEVEL
+  • VERSIONING_SYSTEM
+  • VERSION_INFO_PREFIX
+
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_NAME
+    ◦ $(TARGET_NAME)
+    ◦ $(TARGET_NAME:c99extidentifier)
+
+
+✅ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Base configuration
+❌ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Values
+
+⚠️  Only in first (1):
+
+  • OTHER_LDFLAGS
+
+
+⚠️  Only in second (12):
+
+  • CLANG_ENABLE_MODULES
+  • CURRENT_PROJECT_VERSION
+  • DEFINES_MODULE
+  • DYLIB_COMPATIBILITY_VERSION
+  • DYLIB_CURRENT_VERSION
+  • DYLIB_INSTALL_NAME_BASE
+  • INFOPLIST_FILE
+  • INSTALL_PATH
+  • LD_RUNPATH_SEARCH_PATHS
+  • PRODUCT_BUNDLE_IDENTIFIER
+  • VERSIONING_SYSTEM
+  • VERSION_INFO_PREFIX
+
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_NAME
+    ◦ $(TARGET_NAME)
+    ◦ $(TARGET_NAME:c99extidentifier)
+
+
 ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
 
 ⚠️  Value mismatch (1):
@@ -168,6 +250,11 @@
 
 ❌ SETTINGS > "Project" target > "Debug" configuration > Values
 
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
+
 ⚠️  Value mismatch (1):
 
   • CUSTOM_SETTING_COMMON
@@ -178,6 +265,11 @@
 ✅ SETTINGS > "Project" target > "Release" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Release" configuration > Values
 
+⚠️  Only in second (1):
+
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+
+
 ⚠️  Value mismatch (1):
 
   • CUSTOM_SETTING_COMMON
@@ -186,9 +278,25 @@
 
 
 ✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_BUNDLE_IDENTIFIER
+    ◦ com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework
+    ◦ com.bloomberg.xcdiff.Project.ProjectFramework
+
+
 ✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Base configuration
-✅ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
+
+⚠️  Value mismatch (1):
+
+  • PRODUCT_BUNDLE_IDENTIFIER
+    ◦ com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework
+    ◦ com.bloomberg.xcdiff.Project.ProjectFramework
+
+
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Base configuration
 ✅ SETTINGS > "ProjectTests" target > "Debug" configuration > Values
 ✅ SETTINGS > "ProjectTests" target > "Release" configuration > Base configuration
@@ -200,7 +308,7 @@
 ❌ SOURCE_TREES > Root project
 Output format: (<path>, <name>, <source_tree>)
 
-⚠️  Only in first (7):
+⚠️  Only in first (8):
 
   • (AViewController.xib, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
   • (AnotherObjcClass.h, nil, <group>) → (Group B, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
@@ -208,15 +316,18 @@ Output format: (<path>, <name>, <source_tree>)
   • (BarTests.swift, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (LoginTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
   • (empty.png, nil, <group>) → (Screenshots, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (libMismatchingLibrary.a, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (time.png, nil, <group>) → (Resources, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
 
 
-⚠️  Only in second (9):
+⚠️  Only in second (11):
 
   • (Header4.h, nil, <group>) → (ProjectFramework, nil, <group>) → (nil, nil, <group>)
   • (Info.plist, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (ListResponse.json, nil, <group>) → (Responses, nil, <group>) → (ProjectTests, nil, <group>) → (nil, nil, <group>)
   • (MetricsTests.swift, nil, <group>) → (ProjectUITests, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary-Info.plist, nil, <group>) → (MismatchingLibrary, nil, <group>) → (nil, nil, <group>)
+  • (MismatchingLibrary.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.framework, nil, BUILT_PRODUCTS_DIR) → (nil, Products, <group>) → (nil, nil, <group>)
   • (NewFramework.h, nil, <group>) → (NewFramework, nil, <group>) → (nil, nil, <group>)
   • (Project.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
@@ -224,10 +335,13 @@ Output format: (<path>, <name>, <source_tree>)
   • (Target.xcconfig, nil, <group>) → (Project, nil, <group>) → (nil, nil, <group>)
 
 
+✅ DEPENDENCIES > "MismatchingLibrary" target > Linked Dependencies
+✅ DEPENDENCIES > "MismatchingLibrary" target > Embedded Frameworks
 ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 
@@ -240,8 +354,9 @@ Output format: (<path>, <name>, <source_tree>)
 
 ❌ DEPENDENCIES > "Project" target > Embedded Frameworks
 
-⚠️  Only in second (1):
+⚠️  Only in second (2):
 
+  • MismatchingLibrary.framework
   • NewFramework.framework
 
 

--- a/CommandTests/Manual/p1_p2_differences_only.2.md
+++ b/CommandTests/Manual/p1_p2_differences_only.2.md
@@ -11,6 +11,7 @@
 ❌ FILE_REFERENCES
 ❌ TARGETS > NATIVE targets
 ❌ TARGETS > AGGREGATE targets
+❌ HEADERS > "MismatchingLibrary" target
 ❌ HEADERS > "ProjectFramework" target
 ❌ SOURCES > "Project" target
 ❌ SOURCES > "ProjectTests" target
@@ -22,9 +23,13 @@
 ❌ SETTINGS > Root project > "Debug" configuration > Base configuration
 ❌ SETTINGS > Root project > "Debug" configuration > Values
 ❌ SETTINGS > Root project > "Release" configuration > Values
+❌ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Values
+❌ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Values
 ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
 ❌ SETTINGS > "Project" target > "Debug" configuration > Values
 ❌ SETTINGS > "Project" target > "Release" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Debug" configuration > Values
+❌ SETTINGS > "ProjectFramework" target > "Release" configuration > Values
 ❌ SOURCE_TREES > Root project
 ❌ DEPENDENCIES > "Project" target > Linked Dependencies
 ❌ DEPENDENCIES > "Project" target > Embedded Frameworks

--- a/CommandTests/Manual/p1_p2_g_headers_target_only_in_second.md
+++ b/CommandTests/Manual/p1_p2_g_headers_target_only_in_second.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NewFramework"
+ERROR: Cannot find target "NewFramework" in both projects
 
 ```

--- a/CommandTests/Manual/p1_p2_no_common_targets.2.md
+++ b/CommandTests/Manual/p1_p2_no_common_targets.2.md
@@ -8,6 +8,6 @@
 
 # Expected output
 ```
-ERROR: Cannot find target "NON_EXISTING"
+ERROR: Cannot find target "NON_EXISTING" in both projects
 
 ```

--- a/Fixtures/ios_project_1/MismatchingLibrary/MismatchingLibrary.h
+++ b/Fixtures/ios_project_1/MismatchingLibrary/MismatchingLibrary.h
@@ -1,0 +1,19 @@
+//
+//  MismatchingLibrary.h
+//  MismatchingLibrary
+//
+//  Created by Wridan, Kassem on 15/10/2019.
+//  Copyright © 2019 Bloomberg LP. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for MismatchingLibrary.
+FOUNDATION_EXPORT double MismatchingLibraryVersionNumber;
+
+//! Project version string for MismatchingLibrary.
+FOUNDATION_EXPORT const unsigned char MismatchingLibraryVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <MismatchingLibrary/PublicHeader.h>
+
+

--- a/Fixtures/ios_project_1/MismatchingLibrary/MismatchingLibrary.swift
+++ b/Fixtures/ios_project_1/MismatchingLibrary/MismatchingLibrary.swift
@@ -1,0 +1,11 @@
+//
+//  MismatchingLibrary.swift
+//  MismatchingLibrary
+//
+//  Created by Wridan, Kassem on 15/10/2019.
+//  Copyright © 2019 Bloomberg LP. All rights reserved.
+//
+
+class MismatchingLibrary {
+
+}

--- a/Fixtures/ios_project_1/Project.xcodeproj/project.pbxproj
+++ b/Fixtures/ios_project_1/Project.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		2EB291EA230B29C500C9EB4A /* Header2.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EB291D5230B296500C9EB4A /* Header2.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2EB291EB230B29CA00C9EB4A /* Header3.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EB291D6230B296D00C9EB4A /* Header3.h */; };
 		DC89DE912321357200352EFE /* ARKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC89DE902321357200352EFE /* ARKit.framework */; };
+		FB8D0EEB2355C7C100AB8723 /* MismatchingLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB8D0EEA2355C7C100AB8723 /* MismatchingLibrary.swift */; };
 		FBAE6F0A22F02523004B7BDB /* ObjcClass.m in Sources */ = {isa = PBXBuildFile; fileRef = FBAE6F0922F02523004B7BDB /* ObjcClass.m */; };
 		FBAE6F0E22F02550004B7BDB /* AnotherObjcClass.m in Sources */ = {isa = PBXBuildFile; fileRef = FBAE6F0D22F02550004B7BDB /* AnotherObjcClass.m */; };
 		FBAE6F1122F0263D004B7BDB /* BarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBAE6F1022F0263D004B7BDB /* BarTests.swift */; };
@@ -67,6 +68,15 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FB8D0EE62355C7C100AB8723 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -90,6 +100,9 @@
 		2EB291DE230B29B300C9EB4A /* ProjectFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProjectFramework.h; sourceTree = "<group>"; };
 		2EB291DF230B29B300C9EB4A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DC89DE902321357200352EFE /* ARKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ARKit.framework; path = System/Library/Frameworks/ARKit.framework; sourceTree = SDKROOT; };
+		FB8D0EE82355C7C100AB8723 /* libMismatchingLibrary.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMismatchingLibrary.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		FB8D0EEA2355C7C100AB8723 /* MismatchingLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MismatchingLibrary.swift; sourceTree = "<group>"; };
+		FB8D0EF12355C82500AB8723 /* MismatchingLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MismatchingLibrary.h; sourceTree = "<group>"; };
 		FBAE6F0822F02523004B7BDB /* ObjcClass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcClass.h; sourceTree = "<group>"; };
 		FBAE6F0922F02523004B7BDB /* ObjcClass.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcClass.m; sourceTree = "<group>"; };
 		FBAE6F0C22F02550004B7BDB /* AnotherObjcClass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AnotherObjcClass.h; sourceTree = "<group>"; };
@@ -133,6 +146,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FB8D0EE52355C7C100AB8723 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -143,6 +163,7 @@
 				2E26638B22B7F52600BA59BC /* ProjectTests */,
 				2E26639622B7F52600BA59BC /* ProjectUITests */,
 				2EB291DD230B29B300C9EB4A /* ProjectFramework */,
+				FB8D0EE92355C7C100AB8723 /* MismatchingLibrary */,
 				2E26637522B7F52500BA59BC /* Products */,
 				DC89DE8F2321357200352EFE /* Frameworks */,
 			);
@@ -155,6 +176,7 @@
 				2E26638822B7F52600BA59BC /* ProjectTests.xctest */,
 				2E26639322B7F52600BA59BC /* ProjectUITests.xctest */,
 				2EB291DC230B29B300C9EB4A /* ProjectFramework.framework */,
+				FB8D0EE82355C7C100AB8723 /* libMismatchingLibrary.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -214,6 +236,15 @@
 				DC89DE902321357200352EFE /* ARKit.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		FB8D0EE92355C7C100AB8723 /* MismatchingLibrary */ = {
+			isa = PBXGroup;
+			children = (
+				FB8D0EF12355C82500AB8723 /* MismatchingLibrary.h */,
+				FB8D0EEA2355C7C100AB8723 /* MismatchingLibrary.swift */,
+			);
+			path = MismatchingLibrary;
 			sourceTree = "<group>";
 		};
 		FBAE6F0722F0250D004B7BDB /* Group A */ = {
@@ -342,13 +373,30 @@
 			productReference = 2EB291DC230B29B300C9EB4A /* ProjectFramework.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		FB8D0EE72355C7C100AB8723 /* MismatchingLibrary */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FB8D0EEE2355C7C100AB8723 /* Build configuration list for PBXNativeTarget "MismatchingLibrary" */;
+			buildPhases = (
+				FB8D0EE42355C7C100AB8723 /* Sources */,
+				FB8D0EE52355C7C100AB8723 /* Frameworks */,
+				FB8D0EE62355C7C100AB8723 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MismatchingLibrary;
+			productName = MismatchingLibrary;
+			productReference = FB8D0EE82355C7C100AB8723 /* libMismatchingLibrary.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		2E26636C22B7F52500BA59BC /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1020;
+				LastSwiftUpdateCheck = 1110;
 				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Bloomberg LP";
 				TargetAttributes = {
@@ -366,6 +414,9 @@
 					};
 					2EB291DB230B29B300C9EB4A = {
 						CreatedOnToolsVersion = 10.2.1;
+					};
+					FB8D0EE72355C7C100AB8723 = {
+						CreatedOnToolsVersion = 11.1;
 					};
 				};
 			};
@@ -386,6 +437,7 @@
 				2E26638722B7F52600BA59BC /* ProjectTests */,
 				2E26639222B7F52600BA59BC /* ProjectUITests */,
 				2EB291DB230B29B300C9EB4A /* ProjectFramework */,
+				FB8D0EE72355C7C100AB8723 /* MismatchingLibrary */,
 			);
 		};
 /* End PBXProject section */
@@ -462,6 +514,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FB8D0EE42355C7C100AB8723 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FB8D0EEB2355C7C100AB8723 /* MismatchingLibrary.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -755,7 +815,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.mobile.anywhere.testprovisioning.ProjectFramework;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
@@ -782,13 +842,39 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.mobile.anywhere.testprovisioning.ProjectFramework;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.testprovisioning.ProjectFramework;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		FB8D0EEC2355C7C100AB8723 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		FB8D0EED2355C7C100AB8723 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -836,6 +922,15 @@
 			buildConfigurations = (
 				2EB291E6230B29B300C9EB4A /* Debug */,
 				2EB291E7230B29B300C9EB4A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FB8D0EEE2355C7C100AB8723 /* Build configuration list for PBXNativeTarget "MismatchingLibrary" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FB8D0EEC2355C7C100AB8723 /* Debug */,
+				FB8D0EED2355C7C100AB8723 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Fixtures/ios_project_2/MismatchingLibrary/MismatchingLibrary-Info.plist
+++ b/Fixtures/ios_project_2/MismatchingLibrary/MismatchingLibrary-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Fixtures/ios_project_2/MismatchingLibrary/MismatchingLibrary.h
+++ b/Fixtures/ios_project_2/MismatchingLibrary/MismatchingLibrary.h
@@ -1,0 +1,19 @@
+//
+//  MismatchingLibrary.h
+//  MismatchingLibrary
+//
+//  Created by Wridan, Kassem on 15/10/2019.
+//  Copyright © 2019 Bloomberg LP. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for MismatchingLibrary.
+FOUNDATION_EXPORT double MismatchingLibraryVersionNumber;
+
+//! Project version string for MismatchingLibrary.
+FOUNDATION_EXPORT const unsigned char MismatchingLibraryVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <MismatchingLibrary/PublicHeader.h>
+
+

--- a/Fixtures/ios_project_2/MismatchingLibrary/MismatchingLibrary.swift
+++ b/Fixtures/ios_project_2/MismatchingLibrary/MismatchingLibrary.swift
@@ -1,0 +1,11 @@
+//
+//  MismatchingLibrary.swift
+//  MismatchingLibrary
+//
+//  Created by Wridan, Kassem on 15/10/2019.
+//  Copyright © 2019 Bloomberg LP. All rights reserved.
+//
+
+class MismatchingLibrary {
+
+}

--- a/Fixtures/ios_project_2/Project.xcodeproj/project.pbxproj
+++ b/Fixtures/ios_project_2/Project.xcodeproj/project.pbxproj
@@ -38,6 +38,10 @@
 		2EFBAAD622B9A34600AA5E95 /* NewFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2EFBAACF22B9A34600AA5E95 /* NewFramework.framework */; };
 		2EFBAAD722B9A34600AA5E95 /* NewFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2EFBAACF22B9A34600AA5E95 /* NewFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DC89DE8E2321356300352EFE /* ARKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC89DE8D2321356300352EFE /* ARKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		FB8D0EDB2355C6EF00AB8723 /* MismatchingLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = FB8D0ED92355C6EF00AB8723 /* MismatchingLibrary.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB8D0EDE2355C6EF00AB8723 /* MismatchingLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB8D0ED72355C6EF00AB8723 /* MismatchingLibrary.framework */; };
+		FB8D0EDF2355C6EF00AB8723 /* MismatchingLibrary.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FB8D0ED72355C6EF00AB8723 /* MismatchingLibrary.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		FB8D0EF02355C80A00AB8723 /* MismatchingLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB8D0EEF2355C80A00AB8723 /* MismatchingLibrary.swift */; };
 		FBAE6F0622F0248A004B7BDB /* ObjcClass.m in Sources */ = {isa = PBXBuildFile; fileRef = FBAE6F0522F0248A004B7BDB /* ObjcClass.m */; settings = {COMPILER_FLAGS = "-ObjC"; }; };
 		FBAE6F4822F02746004B7BDB /* MetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBAE6F4722F02746004B7BDB /* MetricsTests.swift */; };
 		FBB3B02322FAE65400EE8176 /* search.png in Resources */ = {isa = PBXBuildFile; fileRef = FBB3B02222FAE65400EE8176 /* search.png */; };
@@ -73,6 +77,13 @@
 			remoteGlobalIDString = 2EFBAACE22B9A34600AA5E95;
 			remoteInfo = NewFramework;
 		};
+		FB8D0EDC2355C6EF00AB8723 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E26636C22B7F52500BA59BC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FB8D0ED62355C6EF00AB8723;
+			remoteInfo = MismatchingLibrary;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -84,6 +95,7 @@
 			files = (
 				2EFBAAD722B9A34600AA5E95 /* NewFramework.framework in Embed Frameworks */,
 				2EB2920A230B2A3E00C9EB4A /* ProjectFramework.framework in Embed Frameworks */,
+				FB8D0EDF2355C6EF00AB8723 /* MismatchingLibrary.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -118,6 +130,10 @@
 		2EFBAAD122B9A34600AA5E95 /* NewFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NewFramework.h; sourceTree = "<group>"; };
 		2EFBAAD222B9A34600AA5E95 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DC89DE8D2321356300352EFE /* ARKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ARKit.framework; path = System/Library/Frameworks/ARKit.framework; sourceTree = SDKROOT; };
+		FB8D0ED72355C6EF00AB8723 /* MismatchingLibrary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MismatchingLibrary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FB8D0ED92355C6EF00AB8723 /* MismatchingLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MismatchingLibrary.h; sourceTree = "<group>"; };
+		FB8D0EDA2355C6EF00AB8723 /* MismatchingLibrary-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "MismatchingLibrary-Info.plist"; sourceTree = "<group>"; };
+		FB8D0EEF2355C80A00AB8723 /* MismatchingLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MismatchingLibrary.swift; sourceTree = "<group>"; };
 		FBAE6F0422F0248A004B7BDB /* ObjcClass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcClass.h; sourceTree = "<group>"; };
 		FBAE6F0522F0248A004B7BDB /* ObjcClass.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcClass.m; sourceTree = "<group>"; };
 		FBAE6F4722F02746004B7BDB /* MetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricsTests.swift; sourceTree = "<group>"; };
@@ -131,6 +147,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DC89DE8E2321356300352EFE /* ARKit.framework in Frameworks */,
+				FB8D0EDE2355C6EF00AB8723 /* MismatchingLibrary.framework in Frameworks */,
 				2EFBAAD622B9A34600AA5E95 /* NewFramework.framework in Frameworks */,
 				2EB29209230B2A3E00C9EB4A /* ProjectFramework.framework in Frameworks */,
 			);
@@ -164,6 +181,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FB8D0ED42355C6EF00AB8723 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -176,6 +200,7 @@
 				2E26639622B7F52600BA59BC /* ProjectUITests */,
 				2EFBAAD022B9A34600AA5E95 /* NewFramework */,
 				2EB29203230B2A3E00C9EB4A /* ProjectFramework */,
+				FB8D0ED82355C6EF00AB8723 /* MismatchingLibrary */,
 				2E26637522B7F52500BA59BC /* Products */,
 				DC89DE8C2321356300352EFE /* Frameworks */,
 			);
@@ -189,6 +214,7 @@
 				2E26639322B7F52600BA59BC /* ProjectUITests.xctest */,
 				2EFBAACF22B9A34600AA5E95 /* NewFramework.framework */,
 				2EB29202230B2A3E00C9EB4A /* ProjectFramework.framework */,
+				FB8D0ED72355C6EF00AB8723 /* MismatchingLibrary.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -261,6 +287,16 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		FB8D0ED82355C6EF00AB8723 /* MismatchingLibrary */ = {
+			isa = PBXGroup;
+			children = (
+				FB8D0ED92355C6EF00AB8723 /* MismatchingLibrary.h */,
+				FB8D0EDA2355C6EF00AB8723 /* MismatchingLibrary-Info.plist */,
+				FB8D0EEF2355C80A00AB8723 /* MismatchingLibrary.swift */,
+			);
+			path = MismatchingLibrary;
+			sourceTree = "<group>";
+		};
 		FBAE6F0322F02466004B7BDB /* Group A */ = {
 			isa = PBXGroup;
 			children = (
@@ -316,6 +352,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FB8D0ED22355C6EF00AB8723 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FB8D0EDB2355C6EF00AB8723 /* MismatchingLibrary.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -333,6 +377,7 @@
 			dependencies = (
 				2EFBAAD522B9A34600AA5E95 /* PBXTargetDependency */,
 				2EB29208230B2A3E00C9EB4A /* PBXTargetDependency */,
+				FB8D0EDD2355C6EF00AB8723 /* PBXTargetDependency */,
 			);
 			name = Project;
 			productName = Project;
@@ -411,6 +456,24 @@
 			productReference = 2EFBAACF22B9A34600AA5E95 /* NewFramework.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		FB8D0ED62355C6EF00AB8723 /* MismatchingLibrary */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FB8D0EE02355C6EF00AB8723 /* Build configuration list for PBXNativeTarget "MismatchingLibrary" */;
+			buildPhases = (
+				FB8D0ED22355C6EF00AB8723 /* Headers */,
+				FB8D0ED32355C6EF00AB8723 /* Sources */,
+				FB8D0ED42355C6EF00AB8723 /* Frameworks */,
+				FB8D0ED52355C6EF00AB8723 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MismatchingLibrary;
+			productName = MismatchingLibrary;
+			productReference = FB8D0ED72355C6EF00AB8723 /* MismatchingLibrary.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -442,6 +505,10 @@
 					2EFBAACE22B9A34600AA5E95 = {
 						CreatedOnToolsVersion = 10.2.1;
 					};
+					FB8D0ED62355C6EF00AB8723 = {
+						CreatedOnToolsVersion = 11.1;
+						LastSwiftMigration = 1110;
+					};
 				};
 			};
 			buildConfigurationList = 2E26636F22B7F52500BA59BC /* Build configuration list for PBXProject "Project" */;
@@ -463,6 +530,7 @@
 				2EFBAAC622B9A28600AA5E95 /* NewAggregate */,
 				2EFBAACE22B9A34600AA5E95 /* NewFramework */,
 				2EB29201230B2A3E00C9EB4A /* ProjectFramework */,
+				FB8D0ED62355C6EF00AB8723 /* MismatchingLibrary */,
 			);
 		};
 /* End PBXProject section */
@@ -502,6 +570,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		2EFBAACD22B9A34600AA5E95 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FB8D0ED52355C6EF00AB8723 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -552,6 +627,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FB8D0ED32355C6EF00AB8723 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FB8D0EF02355C80A00AB8723 /* MismatchingLibrary.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -574,6 +657,11 @@
 			isa = PBXTargetDependency;
 			target = 2EFBAACE22B9A34600AA5E95 /* NewFramework */;
 			targetProxy = 2EFBAAD422B9A34600AA5E95 /* PBXContainerItemProxy */;
+		};
+		FB8D0EDD2355C6EF00AB8723 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FB8D0ED62355C6EF00AB8723 /* MismatchingLibrary */;
+			targetProxy = FB8D0EDC2355C6EF00AB8723 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -720,6 +808,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2E28F9AE230D3468004D2E3F /* Target.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -740,6 +829,7 @@
 		2E26639E22B7F52600BA59BC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -851,7 +941,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.mobile.anywhere.testprovisioning.ProjectFramework;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.ProjectFramework;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
@@ -878,7 +968,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.mobile.anywhere.testprovisioning.ProjectFramework;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.ProjectFramework;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
@@ -1023,6 +1113,7 @@
 		2EFFBEFA230EFCC4008D91E8 /* CUSTOM_NEW */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -1131,7 +1222,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.mobile.anywhere.testprovisioning.ProjectFramework;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.ProjectFramework;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
@@ -1140,6 +1231,92 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = CUSTOM_NEW;
+		};
+		FB8D0EE12355C6EF00AB8723 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "MismatchingLibrary/MismatchingLibrary-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		FB8D0EE22355C6EF00AB8723 /* CUSTOM_NEW */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "MismatchingLibrary/MismatchingLibrary-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = CUSTOM_NEW;
+		};
+		FB8D0EE32355C6EF00AB8723 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "MismatchingLibrary/MismatchingLibrary-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
@@ -1210,6 +1387,16 @@
 				2EFBAAD922B9A34600AA5E95 /* Debug */,
 				2EFFBEFE230EFCC4008D91E8 /* CUSTOM_NEW */,
 				2EFBAADA22B9A34600AA5E95 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FB8D0EE02355C6EF00AB8723 /* Build configuration list for PBXNativeTarget "MismatchingLibrary" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FB8D0EE12355C6EF00AB8723 /* Debug */,
+				FB8D0EE22355C6EF00AB8723 /* CUSTOM_NEW */,
+				FB8D0EE32355C6EF00AB8723 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Sources/XCDiffCore/Library/ComparatorError.swift
+++ b/Sources/XCDiffCore/Library/ComparatorError.swift
@@ -27,7 +27,7 @@ public enum ComparatorError: LocalizedError {
             return message
         case let .cannotFind(type, elements):
             let formattedElemenets = elements.map { "\"\($0)\"" }.joined(separator: ", ")
-            return "Cannot find \(type)\(elements.count > 1 ? "s" : "") \(formattedElemenets)"
+            return "Cannot find \(type)\(elements.count > 1 ? "s" : "") \(formattedElemenets) in both projects"
         }
     }
 }

--- a/Sources/XCDiffCore/Library/TargetsHelper.swift
+++ b/Sources/XCDiffCore/Library/TargetsHelper.swift
@@ -197,6 +197,17 @@ private extension PBXBuildFile {
     }
 }
 
+private extension PBXTarget {
+    func headersBuildPhase() -> PBXHeadersBuildPhase? {
+        return buildPhases
+            .filter { $0.buildPhase == .headers }
+            .compactMap { $0 as? PBXHeadersBuildPhase }
+            .first
+    }
+}
+
+// MARK: - Collection Extensions
+
 extension Set where Set.Element == String {
     func validateTargetsOption(_ parameters: ComparatorParameters) throws {
         try validate(type: "target", option: parameters.targets)
@@ -213,11 +224,8 @@ extension Set where Set.Element == String {
     }
 }
 
-private extension PBXTarget {
-    func headersBuildPhase() -> PBXHeadersBuildPhase? {
-        return buildPhases
-            .filter { $0.buildPhase == .headers }
-            .compactMap { $0 as? PBXHeadersBuildPhase }
-            .first
+extension Array where Array.Element == TargetPair {
+    func filter(by option: ComparatorParameters.Option<String>) -> [TargetPair] {
+        return filter { option.contains($0.first.name) && option.contains($0.second.name) }
     }
 }

--- a/Tests/XCDiffCommandTests/CommandsRunnerTests.swift
+++ b/Tests/XCDiffCommandTests/CommandsRunnerTests.swift
@@ -50,14 +50,17 @@ final class CommandsRunnerTests: XCTestCase {
         ✅ FILE_REFERENCES
         ✅ TARGETS > NATIVE targets
         ✅ TARGETS > AGGREGATE targets
+        ✅ HEADERS > "MismatchingLibrary" target
         ✅ HEADERS > "Project" target
         ✅ HEADERS > "ProjectFramework" target
         ✅ HEADERS > "ProjectTests" target
         ✅ HEADERS > "ProjectUITests" target
+        ✅ SOURCES > "MismatchingLibrary" target
         ✅ SOURCES > "Project" target
         ✅ SOURCES > "ProjectFramework" target
         ✅ SOURCES > "ProjectTests" target
         ✅ SOURCES > "ProjectUITests" target
+        ✅ RESOURCES > "MismatchingLibrary" target
         ✅ RESOURCES > "Project" target
         ✅ RESOURCES > "ProjectFramework" target
         ✅ RESOURCES > "ProjectTests" target
@@ -67,6 +70,10 @@ final class CommandsRunnerTests: XCTestCase {
         ✅ SETTINGS > Root project > "Debug" configuration > Values
         ✅ SETTINGS > Root project > "Release" configuration > Base configuration
         ✅ SETTINGS > Root project > "Release" configuration > Values
+        ✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
+        ✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Values
+        ✅ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Base configuration
+        ✅ SETTINGS > "MismatchingLibrary" target > "Release" configuration > Values
         ✅ SETTINGS > "Project" target > "Debug" configuration > Base configuration
         ✅ SETTINGS > "Project" target > "Debug" configuration > Values
         ✅ SETTINGS > "Project" target > "Release" configuration > Base configuration
@@ -84,6 +91,8 @@ final class CommandsRunnerTests: XCTestCase {
         ✅ SETTINGS > "ProjectUITests" target > "Release" configuration > Base configuration
         ✅ SETTINGS > "ProjectUITests" target > "Release" configuration > Values
         ✅ SOURCE_TREES > Root project
+        ✅ DEPENDENCIES > "MismatchingLibrary" target > Linked Dependencies
+        ✅ DEPENDENCIES > "MismatchingLibrary" target > Embedded Frameworks
         ✅ DEPENDENCIES > "Project" target > Linked Dependencies
         ✅ DEPENDENCIES > "Project" target > Embedded Frameworks
         ✅ DEPENDENCIES > "ProjectFramework" target > Linked Dependencies

--- a/Tests/XCDiffCoreTests/Helpers/PBXNativeTargetBuilder.swift
+++ b/Tests/XCDiffCoreTests/Helpers/PBXNativeTargetBuilder.swift
@@ -36,8 +36,8 @@ final class PBXNativeTargetBuilder {
     private var objects: [PBXObject] = []
     private var fileElements: [PBXFileElement] = []
 
-    init(name: String) {
-        pbxtarget = PBXNativeTarget(name: name)
+    init(name: String, productType: PBXProductType?) {
+        pbxtarget = PBXNativeTarget(name: name, productType: productType)
         objects.append(pbxtarget)
     }
 

--- a/Tests/XCDiffCoreTests/Helpers/PBXProjBuilder.swift
+++ b/Tests/XCDiffCoreTests/Helpers/PBXProjBuilder.swift
@@ -46,8 +46,10 @@ final class PBXProjBuilder {
     }
 
     @discardableResult
-    func addTarget(name: String = "Target", _ closure: ((PBXNativeTargetBuilder) -> Void)? = nil) -> PBXProjBuilder {
-        let builder = PBXNativeTargetBuilder(name: name)
+    func addTarget(name: String = "Target",
+                   productType: PBXProductType? = nil,
+                   _ closure: ((PBXNativeTargetBuilder) -> Void)? = nil) -> PBXProjBuilder {
+        let builder = PBXNativeTargetBuilder(name: name, productType: productType)
         closure?(builder)
         let nativeTargetPrototype = builder.build()
         pbxproject.targets.append(nativeTargetPrototype.pbxtarget)


### PR DESCRIPTION
**Describe your changes**

- When comparing targets, the product type is now compared too
- Updated fixture to include a mismatching target "MismatchingLibrary" where it is a framework in one and a static library in another project
- CommandTests have been updated to reflect those changes

**Testing performed**

- Ran `xcdiff -p1 Fixtures/ios_project_1/Project.xcodeproj -p2 Fixtures/ios_project_2/Project.xcodeproj -g targets -v`
- Verified the product type difference was flagged

e.g.

```
⚠️  Value mismatch (1):

  • MismatchingLibrary product type
    ◦ com.apple.product-type.library.static
    ◦ com.apple.product-type.framework

```
