### PR TITLE
Update version to 0.2.0

### DIFF
--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -49,12 +49,23 @@ xcdiff --help
 
 ### Swift Package Manager
 
-*TODO*
+Add xcdiff to your `Package.swift` file:
 
-### CocoaPods
+```swift
+dependencies: [
+    // ...
+    .package(url: "https://github.com/bloomberg/xcdiff", .upToNextMinor(from: "0.2.0")),
+]
+```
 
-*TODO*
+Then add `XCDiffCore` as a dependency of your target:
 
-### Carthage
+```swift
+// ...
+.target(
+    name: "MyTool",
+    dependencies: ["XCDiffCore"]
+)
+```
 
-*TODO*
+See the [Framework](Framework.md) documentation for more details on how to leverage `XCDiffCore`.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION_MAJOR = 0
-VERSION_MINOR = 1
-VERSION_PATCH = 1
+VERSION_MINOR = 2
+VERSION_PATCH = 0
 VERSION = $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)
 GIT_SHORT_HASH = $(shell git rev-parse --short HEAD)
 
@@ -15,6 +15,8 @@ test:
 
 update_version:
 	sed -i '' 's/\(Version(\)\(.*\)\(, \)/\1$(VERSION_MAJOR), $(VERSION_MINOR), $(VERSION_PATCH)\3/' Sources/XCDiffCommand/Constants.swift
+	sed -i '' 's/upToNextMinor(from: ".*")/upToNextMinor(from: "${VERSION}")/' Documentation/Installation.md
+	sed -i '' 's/output, ".*debug.local/output, "${VERSION}+debug.local/' Tests/XCDiffCommandTests/CommandsRunnerTests.swift
 
 update_hash:
 	sed -i '' 's/#GIT_SHORT_HASH#/$(GIT_SHORT_HASH)/' Sources/XCDiffCommand/Constants.swift

--- a/Sources/XCDiffCommand/Constants.swift
+++ b/Sources/XCDiffCommand/Constants.swift
@@ -24,7 +24,7 @@ final class Constants {
             debugVersionIdentifier(),
             gitHashVersionIdentifier(),
         ].compactMap { $0 }
-        return Version(0, 1, 1, buildMetadataIdentifiers: identifiers)
+        return Version(0, 2, 0, buildMetadataIdentifiers: identifiers)
     }()
 
     private static let gitHash = "#GIT_SHORT_HASH#"

--- a/Tests/XCDiffCommandTests/CommandsRunnerTests.swift
+++ b/Tests/XCDiffCommandTests/CommandsRunnerTests.swift
@@ -186,7 +186,7 @@ final class CommandsRunnerTests: XCTestCase {
         let code = subject.run(with: command)
 
         // Then
-        XCTAssertEqual(printer.output, "0.1.1+debug.local\n")
+        XCTAssertEqual(printer.output, "0.2.0+debug.local\n")
         XCTAssertEqual(code, 0)
     }
 


### PR DESCRIPTION
**Describe your changes**

- Updated the version to 0.2.0
- Updated the makefile to update the test and installation documentation version numbers.

**Testing performed**

- Ran `make update_version`
- Verified version numbers update to reflect those define in the makefile
- Verified running tests via `make test` pass

**Additional context**

I've removed the CocoaPods and Carthage sections for now as we won't be able to support them just yet due to the xcdiff dependencies not all being compatible.
