### PR TITLE
Fix PATH installation documentation

### DIFF
--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -18,7 +18,7 @@ swift build -c release
 The binary will be created in `.build/x86_64-apple-macosx/release/xcdiff`. You can export this path to be able to use the executable from any location in your file system without specifying the full path.
 
 ```sh
-export PATH="$PATH:$(swift -c release --show-bin-path)"
+export PATH="$PATH:$(swift build -c release --show-bin-path)"
 ```
 
 ### Homebrew


### PR DESCRIPTION
**Describe your changes**
The installation instructions were missing the `"build"` to export the binary path.