### PR TITLE
Bump Xcodeproj and Change SPM to version lock

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -20,15 +20,6 @@
         }
       },
       {
-        "package": "Shell",
-        "repositoryURL": "https://github.com/tuist/Shell",
-        "state": {
-          "branch": null,
-          "revision": "d38121f89401db902b0d0bfc30b987e2c84c254e",
-          "version": "2.0.3"
-        }
-      },
-      {
         "package": "Spectre",
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
@@ -41,9 +32,9 @@
         "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
-          "branch": "master",
-          "revision": "9cf3059dfdbf9f38af38be968c2031c3b284501c",
-          "version": null
+          "branch": null,
+          "revision": "f73b84bc1525998e5e267f9d830c1411487ac65e",
+          "version": "0.2.0"
         }
       },
       {
@@ -60,8 +51,8 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
           "branch": null,
-          "revision": "b951777f42e9acbfb8f19da623b43aaa604422f9",
-          "version": "7.0.0"
+          "revision": "23f7e12a7e0db29b4f16052692d99f9fbe41fa15",
+          "version": "7.5.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,9 +50,9 @@
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager",
         "state": {
-          "branch": "swift-5.0-RELEASE",
-          "revision": "3a57975e10be0b1a8b87992ddf3a49701036f96c",
-          "version": null
+          "branch": null,
+          "revision": "9abcc2260438177cecd7cf5185b144d13e74122b",
+          "version": "0.5.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -23,9 +23,9 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-package-manager", .branch("swift-5.0-RELEASE")),
+        .package(url: "https://github.com/apple/swift-package-manager", .upToNextMajor(from: "0.5.0")),
         .package(url: "https://github.com/kylef/PathKit", .upToNextMinor(from: "1.0.0")),
-        .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMinor(from: "7.0.0")),
+        .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMinor(from: "7.5.0")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
**Describe your changes**
Swift package manager as a `.branch` dependency here forces code depending on xcdiff to also use `.branch` when depending on SPM. Version locking might be more flexible. Also, I've updated Xcodeproj. 

**Testing performed**
Run all of xcdiff's tests.
