### PR TITLE
Added install action in the Makefile.

### DIFF
--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -53,7 +53,7 @@ git clone https://github.com/bloomberg/xcdiff.git
 cd xcdiff
 ```
 
-2. Build and copy to `/usr/local/bin `
+2. Build and copy to `/usr/local/bin`
 ```sh
 make install
 ```

--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -45,6 +45,19 @@ Once installed, you can use xcdiff directly:
 xcdiff --help
 ```
 
+### Make
+
+1. Clone the repository
+```sh
+git clone https://github.com/bloomberg/xcdiff.git
+cd xcdiff
+```
+
+2. Build and copy to `/usr/local/bin `
+```sh
+make install
+```
+
 ## Framework
 
 ### Swift Package Manager

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,25 @@ VERSION_PATCH = 0
 VERSION = $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)
 GIT_SHORT_HASH = $(shell git rev-parse --short HEAD)
 
+TOOL_NAME = xcdiff
+PREFIX = /usr/local
+INSTALL_PATH = $(PREFIX)/bin/$(TOOL_NAME)
+BUILD_PATH = .build/release/$(TOOL_NAME)
+LIB_INSTALL_PATH = $(PREFIX)/lib/xcdiff
+
+SWIFT_LIB_FILES = .build/release/AEXML.swiftdoc .build/release/AEXML.swiftmodule .build/release/Basic.swiftdoc .build/release/Basic.swiftmodule .build/release/PathKit.swiftdoc .build/release/PathKit.swiftmodule .build/release/SPMLibc.swiftdoc .build/release/SPMLibc.swiftmodule .build/release/SPMUtility.swiftdoc .build/release/SPMUtility.swiftmodule .build/release/XCDiff.swiftdoc .build/release/XCDiff.swiftmodule .build/release/XCDiffCommand.swiftdoc .build/release/XCDiffCommand.swiftmodule .build/release/XCDiffCore.swiftdoc .build/release/XCDiffCore.swiftmodule .build/release/XcodeProj.swiftdoc .build/release/XcodeProj.swiftmodule
+
 clean:
 	xcrun swift package clean
 
+install: build
+	mkdir -p $(PREFIX)/bin
+	mkdir -p $(PREFIX)/lib/xcdiff
+	cp -f $(BUILD_PATH) $(INSTALL_PATH)
+	cp -f $(SWIFT_LIB_FILES) $(LIB_INSTALL_PATH)
+
 build:
+	swift package clean
 	xcrun swift build --disable-sandbox -c release
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ BUILD_PATH = .build/release/$(TOOL_NAME)
 clean:
 	xcrun swift package clean
 
-install: build
+install: clean build
 	mkdir -p $(PREFIX)/bin
 	cp -f $(BUILD_PATH) $(INSTALL_PATH)
 
-build: clean
+build:
 	xcrun swift build --disable-sandbox -c release
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -6,23 +6,17 @@ GIT_SHORT_HASH = $(shell git rev-parse --short HEAD)
 
 TOOL_NAME = xcdiff
 PREFIX = /usr/local
-INSTALL_PATH = $(PREFIX)/bin/$(TOOL_NAME)
+INSTALL_PATH = $(PREFIX)/bin/
 BUILD_PATH = .build/release/$(TOOL_NAME)
-LIB_INSTALL_PATH = $(PREFIX)/lib/xcdiff
-
-SWIFT_LIB_FILES = .build/release/AEXML.swiftdoc .build/release/AEXML.swiftmodule .build/release/Basic.swiftdoc .build/release/Basic.swiftmodule .build/release/PathKit.swiftdoc .build/release/PathKit.swiftmodule .build/release/SPMLibc.swiftdoc .build/release/SPMLibc.swiftmodule .build/release/SPMUtility.swiftdoc .build/release/SPMUtility.swiftmodule .build/release/XCDiff.swiftdoc .build/release/XCDiff.swiftmodule .build/release/XCDiffCommand.swiftdoc .build/release/XCDiffCommand.swiftmodule .build/release/XCDiffCore.swiftdoc .build/release/XCDiffCore.swiftmodule .build/release/XcodeProj.swiftdoc .build/release/XcodeProj.swiftmodule
 
 clean:
 	xcrun swift package clean
 
 install: build
 	mkdir -p $(PREFIX)/bin
-	mkdir -p $(PREFIX)/lib/xcdiff
 	cp -f $(BUILD_PATH) $(INSTALL_PATH)
-	cp -f $(SWIFT_LIB_FILES) $(LIB_INSTALL_PATH)
 
-build:
-	swift package clean
+build: clean
 	xcrun swift build --disable-sandbox -c release
 
 test:


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #28*

**Describe your changes**
Added install action in the make file that will first build and then create folders and copy all of the products to: `/usr/local/lib/xcdiff`.

**Testing performed**
Installed via: `make install`.

**Additional context**
This is just a proposal, of what we described in issue #28.

Signed-off-by: Todor Brachkov <tbrachkov@gmail.com>