### PR TITLE
Fix issue causing resources within built products to be omitted from results

### DIFF
--- a/Sources/XCDiffCore/Library/TargetsHelper.swift
+++ b/Sources/XCDiffCore/Library/TargetsHelper.swift
@@ -162,7 +162,7 @@ final class TargetsHelper {
     }
 
     private func path(from fileElement: PBXFileElement?, sourceRoot: Path) throws -> String? {
-        return try pathHelper.fullPath(from: fileElement, sourceRoot: sourceRoot)
+        return try pathHelper.fullPath(from: fileElement, sourceRoot: sourceRoot) ?? fileElement?.path
     }
 }
 

--- a/Tests/XCDiffCoreTests/Comparator/ResoucesComparatorTests.swift
+++ b/Tests/XCDiffCoreTests/Comparator/ResoucesComparatorTests.swift
@@ -153,6 +153,41 @@ final class ResourcesComparatorTests: XCTestCase {
         ])
     }
 
+    func testCompare_bundleReferences() throws {
+        // Given
+        let first = project(name: "P1")
+            .addTarget(name: "T1") {
+                $0.addResources([
+                    (name: "A.bundle", sourceTree: .buildProducts),
+                    (name: "B.bundle", sourceTree: .buildProducts),
+                ])
+            }
+            .projectDescriptor()
+        let second = project(name: "P2")
+            .addTarget(name: "T1") {
+                $0.addResources([
+                    (name: "A.bundle", sourceTree: .buildProducts),
+                    (name: "C.bundle", sourceTree: .buildProducts),
+                ])
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first,
+                                         second,
+                                         parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [
+            CompareResult(tag: "resources",
+                          context: ["\"T1\" target"],
+                          description: nil,
+                          onlyInFirst: ["B.bundle"],
+                          onlyInSecond: ["C.bundle"],
+                          differentValues: []),
+        ])
+    }
+
     // MARK: - Helpers
 
     private func noDifference(targets: [String] = []) -> [CompareResult] {

--- a/Tests/XCDiffCoreTests/Helpers/PBXNativeTargetBuilder.swift
+++ b/Tests/XCDiffCoreTests/Helpers/PBXNativeTargetBuilder.swift
@@ -125,10 +125,24 @@ final class PBXNativeTargetBuilder {
     @discardableResult
     func addResources(_ resources: [String]) -> PBXNativeTargetBuilder {
         addBuildPhase(.resources) { buildPhaseBuilder in
-            resources.forEach { source in
+            resources.forEach { resource in
                 buildPhaseBuilder.addBuildFile { buildFileBuilder in
-                    buildFileBuilder.setName(source)
-                    buildFileBuilder.setPath(source)
+                    buildFileBuilder.setName(resource)
+                    buildFileBuilder.setPath(resource)
+                }
+            }
+        }
+        return self
+    }
+
+    @discardableResult
+    func addResources(_ resources: [(name: String, sourceTree: SourceTree)]) -> PBXNativeTargetBuilder {
+        addBuildPhase(.resources) { buildPhaseBuilder in
+            resources.forEach { resource in
+                buildPhaseBuilder.addBuildFile { buildFileBuilder in
+                    buildFileBuilder.setName(resource.name)
+                    buildFileBuilder.setPath(resource.name)
+                    buildFileBuilder.setSourceTree(resource.sourceTree.pbxSourceTree)
                 }
             }
         }
@@ -180,4 +194,16 @@ struct DependencyData {
 struct EmbeddedFrameworksData {
     let path: String
     let settings: [String: [String]]
+}
+
+enum SourceTree {
+    case buildProducts
+    case group
+
+    fileprivate var pbxSourceTree: PBXSourceTree {
+        switch self {
+        case .buildProducts: return .buildProductsDir
+        case .group: return .group
+        }
+    }
 }


### PR DESCRIPTION
**Describe your changes**

- In the event a resource build file can't be to a path relative to the project, the file was getting omitted from the comparison results
- Resource bundles produced by other target reside with the built products directory and don't yield relative paths to the project
- As such when comparing projects that leverage resource bundles, the results didn't include them
- To mitigate this we now fallback to using the file's raw path incase we can't resolve a relative path to it

**Testing performed**

- Ran xcdiff on a project that contains resource bundles
- Verified they appear in the results
- Ran the unit tests

