### PR TITLE
Add swiftpm/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ playground.xcworkspace
 # Package.pins
 # Package.resolved
 .build/
+.swiftpm/
 
 # CocoaPods
 #


### PR DESCRIPTION
Currently we don't have any valid reason to keep it checked in.