### PR TITLE
Fix inaccurate embedded framework comparator results

### DIFF
--- a/CommandTests/Generated/p1_p2_Project_target_console_format_verbose.2.ba4ce842.md
+++ b/CommandTests/Generated/p1_p2_Project_target_console_format_verbose.2.ba4ce842.md
@@ -184,6 +184,13 @@ Output format: (<path>, <name>, <source_tree>)
   • NewFramework.framework
 
 
+⚠️  Value mismatch (1):
+
+  • ProjectFramework.framework Code Sign on Copy
+    ◦ true
+    ◦ false
+
+
 
 
 ```

--- a/CommandTests/Generated/p1_p2_Project_target_json_format.2.1b44ee6e.md
+++ b/CommandTests/Generated/p1_p2_Project_target_json_format.2.1b44ee6e.md
@@ -348,7 +348,11 @@
       "Embedded Frameworks"
     ],
     "differentValues" : [
-
+      {
+        "context" : "ProjectFramework.framework Code Sign on Copy",
+        "first" : "true",
+        "second" : "false"
+      }
     ],
     "onlyInFirst" : [
 

--- a/CommandTests/Generated/p1_p2_Project_target_json_format_verbose.2.bcad53ce.md
+++ b/CommandTests/Generated/p1_p2_Project_target_json_format_verbose.2.bcad53ce.md
@@ -348,7 +348,11 @@
       "Embedded Frameworks"
     ],
     "differentValues" : [
-
+      {
+        "context" : "ProjectFramework.framework Code Sign on Copy",
+        "first" : "true",
+        "second" : "false"
+      }
     ],
     "onlyInFirst" : [
 

--- a/CommandTests/Generated/p1_p2_Project_target_markdown_format_verbose.2.f582a13e.md
+++ b/CommandTests/Generated/p1_p2_Project_target_markdown_format_verbose.2.f582a13e.md
@@ -220,6 +220,13 @@ Output format: (<path>, <name>, <source_tree>)
   - `NewFramework.framework`
 
 
+### ⚠️  Value mismatch (1):
+
+  - `ProjectFramework.framework Code Sign on Copy`
+    - `true`
+    - `false`
+
+
 
 
 ```

--- a/CommandTests/Generated/p1_p2_Project_target_verbose.2.6f518e43.md
+++ b/CommandTests/Generated/p1_p2_Project_target_verbose.2.6f518e43.md
@@ -184,6 +184,13 @@ Output format: (<path>, <name>, <source_tree>)
   • NewFramework.framework
 
 
+⚠️  Value mismatch (1):
+
+  • ProjectFramework.framework Code Sign on Copy
+    ◦ true
+    ◦ false
+
+
 
 
 ```

--- a/CommandTests/Generated/p1_p2_console_format_verbose.2.40a241bd.md
+++ b/CommandTests/Generated/p1_p2_console_format_verbose.2.40a241bd.md
@@ -360,6 +360,13 @@ Output format: (<path>, <name>, <source_tree>)
   • NewFramework.framework
 
 
+⚠️  Value mismatch (1):
+
+  • ProjectFramework.framework Code Sign on Copy
+    ◦ true
+    ◦ false
+
+
 ✅ DEPENDENCIES > "ProjectFramework" target > Linked Dependencies
 ✅ DEPENDENCIES > "ProjectFramework" target > Embedded Frameworks
 ✅ DEPENDENCIES > "ProjectTests" target > Linked Dependencies

--- a/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_console_format_verbose.2.2848daea.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_console_format_verbose.2.2848daea.md
@@ -31,6 +31,13 @@
   • NewFramework.framework
 
 
+⚠️  Value mismatch (1):
+
+  • ProjectFramework.framework Code Sign on Copy
+    ◦ true
+    ◦ false
+
+
 
 
 ```

--- a/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_json_format.2.66701d7e.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_json_format.2.66701d7e.md
@@ -36,7 +36,11 @@
       "Embedded Frameworks"
     ],
     "differentValues" : [
-
+      {
+        "context" : "ProjectFramework.framework Code Sign on Copy",
+        "first" : "true",
+        "second" : "false"
+      }
     ],
     "onlyInFirst" : [
 

--- a/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_json_format_verbose.2.8bc3f1c5.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_json_format_verbose.2.8bc3f1c5.md
@@ -36,7 +36,11 @@
       "Embedded Frameworks"
     ],
     "differentValues" : [
-
+      {
+        "context" : "ProjectFramework.framework Code Sign on Copy",
+        "first" : "true",
+        "second" : "false"
+      }
     ],
     "onlyInFirst" : [
 

--- a/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_markdown_format_verbose.2.139e5b3b.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_markdown_format_verbose.2.139e5b3b.md
@@ -35,6 +35,13 @@
   - `NewFramework.framework`
 
 
+### ⚠️  Value mismatch (1):
+
+  - `ProjectFramework.framework Code Sign on Copy`
+    - `true`
+    - `false`
+
+
 
 
 ```

--- a/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_verbose.2.abaed34d.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_Project_target_verbose.2.abaed34d.md
@@ -31,6 +31,13 @@
   • NewFramework.framework
 
 
+⚠️  Value mismatch (1):
+
+  • ProjectFramework.framework Code Sign on Copy
+    ◦ true
+    ◦ false
+
+
 
 
 ```

--- a/CommandTests/Generated/p1_p2_dependencies_tag_console_format_verbose.2.b4701bc2.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_console_format_verbose.2.b4701bc2.md
@@ -33,6 +33,13 @@
   • NewFramework.framework
 
 
+⚠️  Value mismatch (1):
+
+  • ProjectFramework.framework Code Sign on Copy
+    ◦ true
+    ◦ false
+
+
 ✅ DEPENDENCIES > "ProjectFramework" target > Linked Dependencies
 ✅ DEPENDENCIES > "ProjectFramework" target > Embedded Frameworks
 ✅ DEPENDENCIES > "ProjectTests" target > Linked Dependencies

--- a/CommandTests/Generated/p1_p2_dependencies_tag_json_format.2.fd062de6.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_json_format.2.fd062de6.md
@@ -68,7 +68,11 @@
       "Embedded Frameworks"
     ],
     "differentValues" : [
-
+      {
+        "context" : "ProjectFramework.framework Code Sign on Copy",
+        "first" : "true",
+        "second" : "false"
+      }
     ],
     "onlyInFirst" : [
 

--- a/CommandTests/Generated/p1_p2_dependencies_tag_json_format_verbose.2.e461e65d.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_json_format_verbose.2.e461e65d.md
@@ -68,7 +68,11 @@
       "Embedded Frameworks"
     ],
     "differentValues" : [
-
+      {
+        "context" : "ProjectFramework.framework Code Sign on Copy",
+        "first" : "true",
+        "second" : "false"
+      }
     ],
     "onlyInFirst" : [
 

--- a/CommandTests/Generated/p1_p2_dependencies_tag_markdown_format_verbose.2.af50e3c0.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_markdown_format_verbose.2.af50e3c0.md
@@ -41,6 +41,13 @@
   - `NewFramework.framework`
 
 
+### ⚠️  Value mismatch (1):
+
+  - `ProjectFramework.framework Code Sign on Copy`
+    - `true`
+    - `false`
+
+
 
 ## ✅ DEPENDENCIES > "ProjectFramework" target > Linked Dependencies
 

--- a/CommandTests/Generated/p1_p2_dependencies_tag_verbose.2.023c5888.md
+++ b/CommandTests/Generated/p1_p2_dependencies_tag_verbose.2.023c5888.md
@@ -33,6 +33,13 @@
   • NewFramework.framework
 
 
+⚠️  Value mismatch (1):
+
+  • ProjectFramework.framework Code Sign on Copy
+    ◦ true
+    ◦ false
+
+
 ✅ DEPENDENCIES > "ProjectFramework" target > Linked Dependencies
 ✅ DEPENDENCIES > "ProjectFramework" target > Embedded Frameworks
 ✅ DEPENDENCIES > "ProjectTests" target > Linked Dependencies

--- a/CommandTests/Generated/p1_p2_json_format.2.e54c06ce.md
+++ b/CommandTests/Generated/p1_p2_json_format.2.e54c06ce.md
@@ -884,7 +884,11 @@
       "Embedded Frameworks"
     ],
     "differentValues" : [
-
+      {
+        "context" : "ProjectFramework.framework Code Sign on Copy",
+        "first" : "true",
+        "second" : "false"
+      }
     ],
     "onlyInFirst" : [
 

--- a/CommandTests/Generated/p1_p2_json_format_verbose.2.0e0a3eb6.md
+++ b/CommandTests/Generated/p1_p2_json_format_verbose.2.0e0a3eb6.md
@@ -884,7 +884,11 @@
       "Embedded Frameworks"
     ],
     "differentValues" : [
-
+      {
+        "context" : "ProjectFramework.framework Code Sign on Copy",
+        "first" : "true",
+        "second" : "false"
+      }
     ],
     "onlyInFirst" : [
 

--- a/CommandTests/Generated/p1_p2_markdown_format_verbose.2.ac528bab.md
+++ b/CommandTests/Generated/p1_p2_markdown_format_verbose.2.ac528bab.md
@@ -456,6 +456,13 @@ Output format: (<path>, <name>, <source_tree>)
   - `NewFramework.framework`
 
 
+### ⚠️  Value mismatch (1):
+
+  - `ProjectFramework.framework Code Sign on Copy`
+    - `true`
+    - `false`
+
+
 
 ## ✅ DEPENDENCIES > "ProjectFramework" target > Linked Dependencies
 

--- a/CommandTests/Generated/p1_p2_verbose.2.fe666557.md
+++ b/CommandTests/Generated/p1_p2_verbose.2.fe666557.md
@@ -360,6 +360,13 @@ Output format: (<path>, <name>, <source_tree>)
   • NewFramework.framework
 
 
+⚠️  Value mismatch (1):
+
+  • ProjectFramework.framework Code Sign on Copy
+    ◦ true
+    ◦ false
+
+
 ✅ DEPENDENCIES > "ProjectFramework" target > Linked Dependencies
 ✅ DEPENDENCIES > "ProjectFramework" target > Embedded Frameworks
 ✅ DEPENDENCIES > "ProjectTests" target > Linked Dependencies

--- a/Fixtures/ios_project_2/Project.xcodeproj/project.pbxproj
+++ b/Fixtures/ios_project_2/Project.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		2E26639822B7F52600BA59BC /* ProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E26639722B7F52600BA59BC /* ProjectUITests.swift */; };
 		2EB29206230B2A3E00C9EB4A /* ProjectFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EB29204230B2A3E00C9EB4A /* ProjectFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2EB29209230B2A3E00C9EB4A /* ProjectFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2EB29202230B2A3E00C9EB4A /* ProjectFramework.framework */; };
-		2EB2920A230B2A3E00C9EB4A /* ProjectFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2EB29202230B2A3E00C9EB4A /* ProjectFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		2EB2920A230B2A3E00C9EB4A /* ProjectFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2EB29202230B2A3E00C9EB4A /* ProjectFramework.framework */; };
 		2EB2920F230B2A5100C9EB4A /* Header1.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EB2920E230B2A5100C9EB4A /* Header1.h */; };
 		2EB29213230B2A7800C9EB4A /* Header2.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EB29210230B2A5A00C9EB4A /* Header2.h */; };
 		2EB29214230B2A7C00C9EB4A /* Header3.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EB29212230B2A6C00C9EB4A /* Header3.h */; };

--- a/Sources/XCDiffCore/Library/TargetsHelper.swift
+++ b/Sources/XCDiffCore/Library/TargetsHelper.swift
@@ -153,12 +153,20 @@ final class TargetsHelper {
             return []
         }
         return embeddedFrameworksFiles.compactMap {
-            if let path = $0.file?.path, let settings = $0.settings {
-                let attributes = (settings["ATTRIBUTES"] as? [String]) ?? []
-                return EmbeddedFrameworksDescriptor(path: path, codeSignOnCopy: attributes.contains("CodeSignOnCopy"))
+            if let path = $0.file?.path {
+                return EmbeddedFrameworksDescriptor(path: path,
+                                                    codeSignOnCopy: codeSignAttributes(for: $0))
             }
             return nil
         }
+    }
+
+    private func codeSignAttributes(for file: PBXBuildFile) -> Bool {
+        guard let settings = file.settings else {
+            return false
+        }
+        let attributes = (settings["ATTRIBUTES"] as? [String]) ?? []
+        return attributes.contains("CodeSignOnCopy")
     }
 
     private func path(from fileElement: PBXFileElement?, sourceRoot: Path) throws -> String? {

--- a/Tests/XCDiffCoreTests/Comparator/DependenciesComparatorTests.swift
+++ b/Tests/XCDiffCoreTests/Comparator/DependenciesComparatorTests.swift
@@ -404,6 +404,39 @@ final class DependenciesComparatorTests: XCTestCase {
                                                                       second: "true")])])
     }
 
+    func testCompare_whenDifferentEmbeddedFrameworks_missingCodeSignOnCopy() throws {
+        // Given
+        let first = project(name: "P1")
+            .addTarget(name: "T1") {
+                $0.addEmbeddedFrameworks([EmbeddedFrameworksData(path: "Test1.framework",
+                                                                 settings: nil)])
+            }
+            .projectDescriptor()
+
+        let second = project(name: "P2")
+            .addTarget(name: "T1") {
+                $0.addEmbeddedFrameworks([EmbeddedFrameworksData(path: "Test1.framework",
+                                                                 settings: ["ATTRIBUTES": ["CodeSignOnCopy"]])])
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first,
+                                         second,
+                                         parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [noDifferenceLinkedDependencies(target: "T1"),
+                                CompareResult(tag: "dependencies",
+                                              context: ["\"T1\" target", "Embedded Frameworks"],
+                                              description: nil,
+                                              onlyInFirst: [],
+                                              onlyInSecond: [],
+                                              differentValues: [.init(context: "Test1.framework Code Sign on Copy",
+                                                                      first: "false",
+                                                                      second: "true")])])
+    }
+
     func testCompare_whenDifferentLinkedDependenciesAndEmbeddedFrameworks() throws {
         // Given
         let first = project(name: "P1")

--- a/Tests/XCDiffCoreTests/Helpers/PBXNativeTargetBuilder.swift
+++ b/Tests/XCDiffCoreTests/Helpers/PBXNativeTargetBuilder.swift
@@ -169,7 +169,7 @@ final class PBXNativeTargetBuilder {
             embeddedFrameworks.forEach { embeddedFramework in
                 buildPhaseBuilder.addBuildFile { buildFileBuilder in
                     buildFileBuilder.setPath(embeddedFramework.path)
-                    buildFileBuilder.setSettings(embeddedFramework.settings)
+                    if let settings = embeddedFramework.settings { buildFileBuilder.setSettings(settings) }
                 }
             }
         }
@@ -193,7 +193,7 @@ struct DependencyData {
 
 struct EmbeddedFrameworksData {
     let path: String
-    let settings: [String: [String]]
+    let settings: [String: [String]]?
 }
 
 enum SourceTree {


### PR DESCRIPTION
Resolves: https://github.com/bloomberg/xcdiff/issues/32

**Describe your changes**
- Embedded frameworks that had no settings/attributes within Xcode (e.g. the "Code Sign on Copy" not selected) were omitted from the list of frameworks considered for comparison
- To resolve this we now consider all frameworks (as long as they have a `path` set)
- Fixtures have been updated to test for this scenario

**Test plan**
- Run `xcdiff -g dependencies -v` with the `Fixtures` folder
- Verify the `ProjectFramework.framework` is listed as having different code sign attributes




