### PR TITLE
Fix SettingsComparator to handle missing configurations

### DIFF
--- a/Sources/XCDiffCore/Comparator/SettingsComparator.swift
+++ b/Sources/XCDiffCore/Comparator/SettingsComparator.swift
@@ -101,20 +101,31 @@ final class SettingsComparator: Comparator {
             return results(context: context,
                            onlyInSecond: ["\"\(configurationName)\" configuration"])
         default:
-            guard let firstConfiguration = first?.configuration(name: configurationName) else {
-                throw ComparatorError.generic("Configuration not found")
-            }
-            guard let secondConfiguration = second?.configuration(name: configurationName) else {
-                throw ComparatorError.generic("Configuration not found")
-            }
-            let baseConfigurations = try compareBaseConfigurations(parentContext: context,
-                                                                   firstConfiguration, secondConfiguration,
-                                                                   firstSourceRoot: firstSourceRoot,
-                                                                   secondSourceRoot: secondSourceRoot)
-            let settingsValues = try compareSettingsValues(parentContext: context,
-                                                           firstConfiguration, secondConfiguration)
-            return [baseConfigurations, settingsValues]
+            break
         }
+        let firstConfigurationOptional = first?.configuration(name: configurationName)
+        let secondConfigurationOptional = second?.configuration(name: configurationName)
+        guard let firstConfiguration = firstConfigurationOptional,
+            let secondConfiguration = secondConfigurationOptional else {
+            if firstConfigurationOptional == nil, secondConfigurationOptional == nil {
+                return [CompareResult(tag: tag, context: context)]
+            }
+            if firstConfigurationOptional == nil {
+                return results(context: context,
+                               onlyInSecond: ["\"\(configurationName)\" configuration"])
+            } else {
+                return results(context: context,
+                               onlyInFirst: ["\"\(configurationName)\" configuration"])
+            }
+        }
+
+        let baseConfigurations = try compareBaseConfigurations(parentContext: context,
+                                                               firstConfiguration, secondConfiguration,
+                                                               firstSourceRoot: firstSourceRoot,
+                                                               secondSourceRoot: secondSourceRoot)
+        let settingsValues = try compareSettingsValues(parentContext: context,
+                                                       firstConfiguration, secondConfiguration)
+        return [baseConfigurations, settingsValues]
     }
 
     private func compareSettingsValues(parentContext: [String],

--- a/Tests/XCDiffCoreTests/Comparator/SettingsComparatorTests.swift
+++ b/Tests/XCDiffCoreTests/Comparator/SettingsComparatorTests.swift
@@ -416,6 +416,95 @@ final class SettingsComparatorTests: XCTestCase {
                   context: ["\"Target\" target", "\"Debug\" configuration"]),
         ])
     }
+
+    func testCompare_whenFirstHasEmptyConfigurationList() throws {
+        // Given
+        let first = project()
+            .addBuildConfiguration(name: "Debug")
+            .addTarget {
+                $0.addBuildConfigurationList()
+            }
+            .projectDescriptor()
+        let second = project()
+            .addBuildConfiguration(name: "Debug")
+            .addTarget {
+                $0.addBuildConfiguration(name: "Debug")
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first, second, parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [
+            .init(tag: "settings",
+                  context: ["Root project", "\"Debug\" configuration", "Base configuration"]),
+            .init(tag: "settings",
+                  context: ["Root project", "\"Debug\" configuration", "Values"]),
+            .init(tag: "settings",
+                  context: ["\"Target\" target", "\"Debug\" configuration"],
+                  onlyInSecond: ["\"Debug\" configuration"]),
+        ])
+    }
+
+    func testCompare_whenSecondHasEmptyConfigurationList() throws {
+        // Given
+        let first = project()
+            .addBuildConfiguration(name: "Debug")
+            .addTarget {
+                $0.addBuildConfiguration(name: "Debug")
+            }
+            .projectDescriptor()
+        let second = project()
+            .addBuildConfiguration(name: "Debug")
+            .addTarget {
+                $0.addBuildConfigurationList()
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first, second, parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [
+            .init(tag: "settings",
+                  context: ["Root project", "\"Debug\" configuration", "Base configuration"]),
+            .init(tag: "settings",
+                  context: ["Root project", "\"Debug\" configuration", "Values"]),
+            .init(tag: "settings",
+                  context: ["\"Target\" target", "\"Debug\" configuration"],
+                  onlyInFirst: ["\"Debug\" configuration"]),
+        ])
+    }
+
+    func testCompare_whenBothHaveEmptyConfigurationList() throws {
+        // Given
+        let first = project()
+            .addBuildConfiguration(name: "Debug")
+            .addTarget {
+                $0.addBuildConfigurationList()
+            }
+            .projectDescriptor()
+        let second = project()
+            .addBuildConfiguration(name: "Debug")
+            .addTarget {
+                $0.addBuildConfigurationList()
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first, second, parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [
+            .init(tag: "settings",
+                  context: ["Root project", "\"Debug\" configuration", "Base configuration"]),
+            .init(tag: "settings",
+                  context: ["Root project", "\"Debug\" configuration", "Values"]),
+            .init(tag: "settings",
+                  context: ["\"Target\" target", "\"Debug\" configuration"]),
+        ])
+    }
 }
 
 // swiftlint:enable type_body_length

--- a/Tests/XCDiffCoreTests/Helpers/PBXNativeTargetBuilder.swift
+++ b/Tests/XCDiffCoreTests/Helpers/PBXNativeTargetBuilder.swift
@@ -48,6 +48,17 @@ final class PBXNativeTargetBuilder {
     }
 
     @discardableResult
+    func addBuildConfigurationList() -> PBXNativeTargetBuilder {
+        if pbxtarget.buildConfigurationList != nil {
+            return self
+        }
+        let buildConfigurationList = XCConfigurationList()
+        pbxtarget.buildConfigurationList = buildConfigurationList
+        objects.append(buildConfigurationList)
+        return self
+    }
+
+    @discardableResult
     func addBuildConfiguration(name: String, _ closure: ((PBXBuildConfigurationBuilder) -> Void)? = nil)
         -> PBXNativeTargetBuilder {
         let builder = PBXBuildConfigurationBuilder(name: name)


### PR DESCRIPTION
**Describe your changes**
For some projects, `SettingsComparator` can return enigmatic error messages "ERROR: Configuration not found". We didn't expect to the targets to contain an empty `XCConfigurationList` but it looks, it's a valid scenario. 
Update the logic so an empty list is handled in the same way as missing `XCConfigurationList`. When one of the targets has a valid configuration object, but the second does not have configuration or has an empty configuration list, "only in..." error will be triggered.

**Testing performed**
CI
