### PR TITLE
Setup codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ playground.xcworkspace
 .build/
 .swiftpm/
 
+# Coverage
+.coverage/
+
 # CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ osx_image: xcode11.1
 script:
   - ./Scripts/brew.sh ; make lint
   - make clean build
-  - make clean test
+  - make clean test ; ./Scripts/coverage.sh

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build:
 	xcrun swift build --disable-sandbox -c release
 
 test:
-	xcrun swift test
+	xcrun swift test --enable-code-coverage
 
 update_version:
 	sed -i '' 's/\(Version(\)\(.*\)\(, \)/\1$(VERSION_MAJOR), $(VERSION_MINOR), $(VERSION_PATCH)\3/' Sources/XCDiffCommand/Constants.swift

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </p>
 
 [![Build Status](https://travis-ci.com/bloomberg/xcdiff.svg?branch=master)](https://travis-ci.com/bloomberg/xcdiff)
+[![Coverage Status](https://codecov.io/gh/bloomberg/xcdiff/branch/master/graph/badge.svg)](https://codecov.io/gh/bloomberg/xcdiff)
 
 *xcdiff* is an extensible tool that **finds differences between two .xcodeproj project files**. It can be thought of as git diff for .xcodeproj files, which can be used directly from the command line as well as a library supporting your own set of tools.
 

--- a/Scripts/coverage.sh
+++ b/Scripts/coverage.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# don't pipe on failure
+set -o pipefail
+
+# exit on error
+trap 'exit' ERR
+
+# create coverage directory
+mkdir -p .coverage
+
+# export the coverage output to lcov format
+xcrun llvm-cov export -format="lcov" .build/debug/xcdiff -instr-profile .build/debug/codecov/default.profdata > ./.coverage/coverage.lcov
+
+# upload coverage data
+bash <(curl -s https://codecov.io/bash) -D .coverage


### PR DESCRIPTION
**Describe your changes**
Set up codecov.io to make the code coverage data more visible for the contributors. 

**Testing performed**
I was primarily testing the integration locally and via this PR.

**Additional context**
Thanks @kwridan for pushing back on xcodebuild. Using `swift test` is a way better option. Glad I've found @wnagrodzki 's comment (https://community.codecov.io/t/swift-package-support/675)
