### PR TITLE
Switch to Xcode 11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: swift
 os: osx
-osx_image: xcode10.3
+osx_image: xcode11.1
 script:
   - ./Scripts/brew.sh ; make lint
   - make clean build


### PR DESCRIPTION
**Describe your changes**
Update travis CI configuration to use Xcode 11.1.

**Testing performed**
CI

**Additional context**
Required to leverage new llvm-cov output format produced by SwiftPM (`--enable-code-coverage`)
