### PR TITLE
Add build phases comparator

### DIFF
--- a/CommandTests/Generated/differences_only.2.42311ee5.md
+++ b/CommandTests/Generated/differences_only.2.42311ee5.md
@@ -9,6 +9,7 @@
 # Expected output
 ```
 ❌ FILE_REFERENCES
+❌ BUILD_PHASES > "MismatchingLibrary" target
 ❌ TARGETS > NATIVE targets
 ❌ TARGETS > AGGREGATE targets
 ❌ HEADERS > "MismatchingLibrary" target

--- a/CommandTests/Generated/list.0.a330395c.md
+++ b/CommandTests/Generated/list.0.a330395c.md
@@ -9,6 +9,7 @@
 # Expected output
 ```
 - FILE_REFERENCES
+- BUILD_PHASES
 - TARGETS
 - HEADERS
 - SOURCES

--- a/CommandTests/Generated/p1_p2.2.bac5a245.md
+++ b/CommandTests/Generated/p1_p2.2.bac5a245.md
@@ -9,6 +9,11 @@
 # Expected output
 ```
 ❌ FILE_REFERENCES
+❌ BUILD_PHASES > "MismatchingLibrary" target
+✅ BUILD_PHASES > "Project" target
+✅ BUILD_PHASES > "ProjectFramework" target
+✅ BUILD_PHASES > "ProjectTests" target
+✅ BUILD_PHASES > "ProjectUITests" target
 ❌ TARGETS > NATIVE targets
 ❌ TARGETS > AGGREGATE targets
 ❌ HEADERS > "MismatchingLibrary" target

--- a/CommandTests/Generated/p1_p2_Project_target.2.961f27cf.md
+++ b/CommandTests/Generated/p1_p2_Project_target.2.961f27cf.md
@@ -9,6 +9,7 @@
 # Expected output
 ```
 ❌ FILE_REFERENCES
+✅ BUILD_PHASES > "Project" target
 ✅ TARGETS > NATIVE targets
 ✅ TARGETS > AGGREGATE targets
 ✅ HEADERS > "Project" target

--- a/CommandTests/Generated/p1_p2_Project_target_console_format.2.dfbdb9cf.md
+++ b/CommandTests/Generated/p1_p2_Project_target_console_format.2.dfbdb9cf.md
@@ -9,6 +9,7 @@
 # Expected output
 ```
 ❌ FILE_REFERENCES
+✅ BUILD_PHASES > "Project" target
 ✅ TARGETS > NATIVE targets
 ✅ TARGETS > AGGREGATE targets
 ✅ HEADERS > "Project" target

--- a/CommandTests/Generated/p1_p2_Project_target_console_format_verbose.2.ba4ce842.md
+++ b/CommandTests/Generated/p1_p2_Project_target_console_format_verbose.2.ba4ce842.md
@@ -37,6 +37,7 @@
   • README.md
 
 
+✅ BUILD_PHASES > "Project" target
 ✅ TARGETS > NATIVE targets
 ✅ TARGETS > AGGREGATE targets
 ✅ HEADERS > "Project" target

--- a/CommandTests/Generated/p1_p2_Project_target_json_format.2.1b44ee6e.md
+++ b/CommandTests/Generated/p1_p2_Project_target_json_format.2.1b44ee6e.md
@@ -43,6 +43,21 @@
   },
   {
     "context" : [
+      "\"Project\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "build_phases"
+  },
+  {
+    "context" : [
       "NATIVE targets"
     ],
     "differentValues" : [

--- a/CommandTests/Generated/p1_p2_Project_target_json_format_verbose.2.bcad53ce.md
+++ b/CommandTests/Generated/p1_p2_Project_target_json_format_verbose.2.bcad53ce.md
@@ -43,6 +43,21 @@
   },
   {
     "context" : [
+      "\"Project\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "build_phases"
+  },
+  {
+    "context" : [
       "NATIVE targets"
     ],
     "differentValues" : [

--- a/CommandTests/Generated/p1_p2_Project_target_markdown_format.2.d851dd25.md
+++ b/CommandTests/Generated/p1_p2_Project_target_markdown_format.2.d851dd25.md
@@ -12,6 +12,9 @@
 ## ❌ FILE_REFERENCES
 
 
+## ✅ BUILD_PHASES > "Project" target
+
+
 ## ✅ TARGETS > NATIVE targets
 
 

--- a/CommandTests/Generated/p1_p2_Project_target_markdown_format_verbose.2.f582a13e.md
+++ b/CommandTests/Generated/p1_p2_Project_target_markdown_format_verbose.2.f582a13e.md
@@ -40,6 +40,9 @@
 
 
 
+## ✅ BUILD_PHASES > "Project" target
+
+
 ## ✅ TARGETS > NATIVE targets
 
 

--- a/CommandTests/Generated/p1_p2_Project_target_verbose.2.6f518e43.md
+++ b/CommandTests/Generated/p1_p2_Project_target_verbose.2.6f518e43.md
@@ -37,6 +37,7 @@
   • README.md
 
 
+✅ BUILD_PHASES > "Project" target
 ✅ TARGETS > NATIVE targets
 ✅ TARGETS > AGGREGATE targets
 ✅ HEADERS > "Project" target

--- a/CommandTests/Generated/p1_p2_console_format.2.9841a8d7.md
+++ b/CommandTests/Generated/p1_p2_console_format.2.9841a8d7.md
@@ -9,6 +9,11 @@
 # Expected output
 ```
 ❌ FILE_REFERENCES
+❌ BUILD_PHASES > "MismatchingLibrary" target
+✅ BUILD_PHASES > "Project" target
+✅ BUILD_PHASES > "ProjectFramework" target
+✅ BUILD_PHASES > "ProjectTests" target
+✅ BUILD_PHASES > "ProjectUITests" target
 ❌ TARGETS > NATIVE targets
 ❌ TARGETS > AGGREGATE targets
 ❌ HEADERS > "MismatchingLibrary" target

--- a/CommandTests/Generated/p1_p2_console_format_verbose.2.40a241bd.md
+++ b/CommandTests/Generated/p1_p2_console_format_verbose.2.40a241bd.md
@@ -37,6 +37,31 @@
   • README.md
 
 
+❌ BUILD_PHASES > "MismatchingLibrary" target
+
+⚠️  Value mismatch (4):
+
+  • Build Phase 1
+    ◦ name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false
+    ◦ name = Headers, type = Headers, runOnlyForDeploymentPostprocessing = false
+
+  • Build Phase 2
+    ◦ name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false
+    ◦ name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false
+
+  • Build Phase 3
+    ◦ name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false
+    ◦ name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false
+
+  • Build Phase 4
+    ◦ nil
+    ◦ name = Resources, type = Resources, runOnlyForDeploymentPostprocessing = false
+
+
+✅ BUILD_PHASES > "Project" target
+✅ BUILD_PHASES > "ProjectFramework" target
+✅ BUILD_PHASES > "ProjectTests" target
+✅ BUILD_PHASES > "ProjectUITests" target
 ❌ TARGETS > NATIVE targets
 
 ⚠️  Only in second (1):

--- a/CommandTests/Generated/p1_p2_console_format_verbose.2.40a241bd.md
+++ b/CommandTests/Generated/p1_p2_console_format_verbose.2.40a241bd.md
@@ -39,23 +39,15 @@
 
 ❌ BUILD_PHASES > "MismatchingLibrary" target
 
-⚠️  Value mismatch (4):
+⚠️  Only in first (1):
 
-  • Build Phase 1
-    ◦ name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false
-    ◦ name = Headers, type = Headers, runOnlyForDeploymentPostprocessing = false
+  • CopyFiles
 
-  • Build Phase 2
-    ◦ name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false
-    ◦ name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false
 
-  • Build Phase 3
-    ◦ name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false
-    ◦ name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false
+⚠️  Only in second (2):
 
-  • Build Phase 4
-    ◦ nil
-    ◦ name = Resources, type = Resources, runOnlyForDeploymentPostprocessing = false
+  • Headers
+  • Resources
 
 
 ✅ BUILD_PHASES > "Project" target

--- a/CommandTests/Generated/p1_p2_json_format.2.e54c06ce.md
+++ b/CommandTests/Generated/p1_p2_json_format.2.e54c06ce.md
@@ -46,32 +46,14 @@
       "\"MismatchingLibrary\" target"
     ],
     "differentValues" : [
-      {
-        "context" : "Build Phase 1",
-        "first" : "name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false",
-        "second" : "name = Headers, type = Headers, runOnlyForDeploymentPostprocessing = false"
-      },
-      {
-        "context" : "Build Phase 2",
-        "first" : "name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false",
-        "second" : "name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false"
-      },
-      {
-        "context" : "Build Phase 3",
-        "first" : "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false",
-        "second" : "name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false"
-      },
-      {
-        "context" : "Build Phase 4",
-        "first" : "nil",
-        "second" : "name = Resources, type = Resources, runOnlyForDeploymentPostprocessing = false"
-      }
+
     ],
     "onlyInFirst" : [
-
+      "CopyFiles"
     ],
     "onlyInSecond" : [
-
+      "Headers",
+      "Resources"
     ],
     "tag" : "build_phases"
   },

--- a/CommandTests/Generated/p1_p2_json_format.2.e54c06ce.md
+++ b/CommandTests/Generated/p1_p2_json_format.2.e54c06ce.md
@@ -43,6 +43,100 @@
   },
   {
     "context" : [
+      "\"MismatchingLibrary\" target"
+    ],
+    "differentValues" : [
+      {
+        "context" : "Build Phase 1",
+        "first" : "name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false",
+        "second" : "name = Headers, type = Headers, runOnlyForDeploymentPostprocessing = false"
+      },
+      {
+        "context" : "Build Phase 2",
+        "first" : "name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false",
+        "second" : "name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false"
+      },
+      {
+        "context" : "Build Phase 3",
+        "first" : "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false",
+        "second" : "name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false"
+      },
+      {
+        "context" : "Build Phase 4",
+        "first" : "nil",
+        "second" : "name = Resources, type = Resources, runOnlyForDeploymentPostprocessing = false"
+      }
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "build_phases"
+  },
+  {
+    "context" : [
+      "\"Project\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "build_phases"
+  },
+  {
+    "context" : [
+      "\"ProjectFramework\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "build_phases"
+  },
+  {
+    "context" : [
+      "\"ProjectTests\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "build_phases"
+  },
+  {
+    "context" : [
+      "\"ProjectUITests\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "build_phases"
+  },
+  {
+    "context" : [
       "NATIVE targets"
     ],
     "differentValues" : [

--- a/CommandTests/Generated/p1_p2_json_format_verbose.2.0e0a3eb6.md
+++ b/CommandTests/Generated/p1_p2_json_format_verbose.2.0e0a3eb6.md
@@ -46,32 +46,14 @@
       "\"MismatchingLibrary\" target"
     ],
     "differentValues" : [
-      {
-        "context" : "Build Phase 1",
-        "first" : "name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false",
-        "second" : "name = Headers, type = Headers, runOnlyForDeploymentPostprocessing = false"
-      },
-      {
-        "context" : "Build Phase 2",
-        "first" : "name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false",
-        "second" : "name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false"
-      },
-      {
-        "context" : "Build Phase 3",
-        "first" : "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false",
-        "second" : "name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false"
-      },
-      {
-        "context" : "Build Phase 4",
-        "first" : "nil",
-        "second" : "name = Resources, type = Resources, runOnlyForDeploymentPostprocessing = false"
-      }
+
     ],
     "onlyInFirst" : [
-
+      "CopyFiles"
     ],
     "onlyInSecond" : [
-
+      "Headers",
+      "Resources"
     ],
     "tag" : "build_phases"
   },

--- a/CommandTests/Generated/p1_p2_json_format_verbose.2.0e0a3eb6.md
+++ b/CommandTests/Generated/p1_p2_json_format_verbose.2.0e0a3eb6.md
@@ -43,6 +43,100 @@
   },
   {
     "context" : [
+      "\"MismatchingLibrary\" target"
+    ],
+    "differentValues" : [
+      {
+        "context" : "Build Phase 1",
+        "first" : "name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false",
+        "second" : "name = Headers, type = Headers, runOnlyForDeploymentPostprocessing = false"
+      },
+      {
+        "context" : "Build Phase 2",
+        "first" : "name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false",
+        "second" : "name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false"
+      },
+      {
+        "context" : "Build Phase 3",
+        "first" : "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false",
+        "second" : "name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false"
+      },
+      {
+        "context" : "Build Phase 4",
+        "first" : "nil",
+        "second" : "name = Resources, type = Resources, runOnlyForDeploymentPostprocessing = false"
+      }
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "build_phases"
+  },
+  {
+    "context" : [
+      "\"Project\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "build_phases"
+  },
+  {
+    "context" : [
+      "\"ProjectFramework\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "build_phases"
+  },
+  {
+    "context" : [
+      "\"ProjectTests\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "build_phases"
+  },
+  {
+    "context" : [
+      "\"ProjectUITests\" target"
+    ],
+    "differentValues" : [
+
+    ],
+    "onlyInFirst" : [
+
+    ],
+    "onlyInSecond" : [
+
+    ],
+    "tag" : "build_phases"
+  },
+  {
+    "context" : [
       "NATIVE targets"
     ],
     "differentValues" : [

--- a/CommandTests/Generated/p1_p2_markdown_format.2.1e09644b.md
+++ b/CommandTests/Generated/p1_p2_markdown_format.2.1e09644b.md
@@ -12,6 +12,21 @@
 ## ❌ FILE_REFERENCES
 
 
+## ❌ BUILD_PHASES > "MismatchingLibrary" target
+
+
+## ✅ BUILD_PHASES > "Project" target
+
+
+## ✅ BUILD_PHASES > "ProjectFramework" target
+
+
+## ✅ BUILD_PHASES > "ProjectTests" target
+
+
+## ✅ BUILD_PHASES > "ProjectUITests" target
+
+
 ## ❌ TARGETS > NATIVE targets
 
 

--- a/CommandTests/Generated/p1_p2_markdown_format_verbose.2.ac528bab.md
+++ b/CommandTests/Generated/p1_p2_markdown_format_verbose.2.ac528bab.md
@@ -43,23 +43,15 @@
 ## ❌ BUILD_PHASES > "MismatchingLibrary" target
 
 
-### ⚠️  Value mismatch (4):
+### ⚠️  Only in first (1):
 
-  - `Build Phase 1`
-    - `name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false`
-    - `name = Headers, type = Headers, runOnlyForDeploymentPostprocessing = false`
+  - `CopyFiles`
 
-  - `Build Phase 2`
-    - `name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false`
-    - `name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false`
 
-  - `Build Phase 3`
-    - `name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false`
-    - `name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false`
+### ⚠️  Only in second (2):
 
-  - `Build Phase 4`
-    - `nil`
-    - `name = Resources, type = Resources, runOnlyForDeploymentPostprocessing = false`
+  - `Headers`
+  - `Resources`
 
 
 

--- a/CommandTests/Generated/p1_p2_markdown_format_verbose.2.ac528bab.md
+++ b/CommandTests/Generated/p1_p2_markdown_format_verbose.2.ac528bab.md
@@ -40,6 +40,41 @@
 
 
 
+## ❌ BUILD_PHASES > "MismatchingLibrary" target
+
+
+### ⚠️  Value mismatch (4):
+
+  - `Build Phase 1`
+    - `name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false`
+    - `name = Headers, type = Headers, runOnlyForDeploymentPostprocessing = false`
+
+  - `Build Phase 2`
+    - `name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false`
+    - `name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false`
+
+  - `Build Phase 3`
+    - `name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false`
+    - `name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false`
+
+  - `Build Phase 4`
+    - `nil`
+    - `name = Resources, type = Resources, runOnlyForDeploymentPostprocessing = false`
+
+
+
+## ✅ BUILD_PHASES > "Project" target
+
+
+## ✅ BUILD_PHASES > "ProjectFramework" target
+
+
+## ✅ BUILD_PHASES > "ProjectTests" target
+
+
+## ✅ BUILD_PHASES > "ProjectUITests" target
+
+
 ## ❌ TARGETS > NATIVE targets
 
 

--- a/CommandTests/Generated/p1_p2_verbose.2.fe666557.md
+++ b/CommandTests/Generated/p1_p2_verbose.2.fe666557.md
@@ -37,6 +37,31 @@
   • README.md
 
 
+❌ BUILD_PHASES > "MismatchingLibrary" target
+
+⚠️  Value mismatch (4):
+
+  • Build Phase 1
+    ◦ name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false
+    ◦ name = Headers, type = Headers, runOnlyForDeploymentPostprocessing = false
+
+  • Build Phase 2
+    ◦ name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false
+    ◦ name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false
+
+  • Build Phase 3
+    ◦ name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false
+    ◦ name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false
+
+  • Build Phase 4
+    ◦ nil
+    ◦ name = Resources, type = Resources, runOnlyForDeploymentPostprocessing = false
+
+
+✅ BUILD_PHASES > "Project" target
+✅ BUILD_PHASES > "ProjectFramework" target
+✅ BUILD_PHASES > "ProjectTests" target
+✅ BUILD_PHASES > "ProjectUITests" target
 ❌ TARGETS > NATIVE targets
 
 ⚠️  Only in second (1):

--- a/CommandTests/Generated/p1_p2_verbose.2.fe666557.md
+++ b/CommandTests/Generated/p1_p2_verbose.2.fe666557.md
@@ -39,23 +39,15 @@
 
 ❌ BUILD_PHASES > "MismatchingLibrary" target
 
-⚠️  Value mismatch (4):
+⚠️  Only in first (1):
 
-  • Build Phase 1
-    ◦ name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false
-    ◦ name = Headers, type = Headers, runOnlyForDeploymentPostprocessing = false
+  • CopyFiles
 
-  • Build Phase 2
-    ◦ name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false
-    ◦ name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false
 
-  • Build Phase 3
-    ◦ name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false
-    ◦ name = Frameworks, type = Frameworks, runOnlyForDeploymentPostprocessing = false
+⚠️  Only in second (2):
 
-  • Build Phase 4
-    ◦ nil
-    ◦ name = Resources, type = Resources, runOnlyForDeploymentPostprocessing = false
+  • Headers
+  • Resources
 
 
 ✅ BUILD_PHASES > "Project" target

--- a/Documentation/Comparators.md
+++ b/Documentation/Comparators.md
@@ -2,6 +2,10 @@
 
 The list of built-in comparators available in xcdiff.
 
+### `build_phases`
+
+Compares build phases i.e. dependencies, sources, headers, to ensure all are present in both projects in the same order.
+
 ### `configurations`
 
 Compares build configurations i.e. Debug, Release.

--- a/Sources/XCDiffCore/Comparator/BuildPhasesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/BuildPhasesComparator.swift
@@ -1,0 +1,95 @@
+//
+// Copyright 2019 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import XcodeProj
+
+final class BuildPhasesComparator: Comparator {
+    let tag = "build_phases"
+    private let targetsHelper = TargetsHelper()
+
+    func compare(_ first: ProjectDescriptor, _ second: ProjectDescriptor,
+                 parameters: ComparatorParameters) throws -> [CompareResult] {
+        return try targetsHelper.commonTargets(first, second, parameters: parameters).map(compare)
+    }
+
+    // MARK: - Private
+
+    private func compare(_ first: PBXTarget, _ second: PBXTarget) -> CompareResult {
+        let context = ["\"\(first.name)\" target"]
+        let firstDescriptors = first.buildPhases.map { $0.descriptor() }
+        let secondDescriptors = second.buildPhases.map { $0.descriptor() }
+        let count = max(firstDescriptors.count, secondDescriptors.count)
+        let differentValues: [CompareResult.DifferentValues] = (0 ..< count).compactMap { index in
+            let context = "Build Phase \(index + 1)"
+            guard let firstDescriptor = firstDescriptors[safe: index] else {
+                if let secondDescriptor = secondDescriptors[safe: index] {
+                    return .init(context: context,
+                                 first: nil,
+                                 second: secondDescriptor.description)
+                }
+                return nil
+            }
+            guard let secondDescriptor = secondDescriptors[safe: index] else {
+                if let firstDescriptor = firstDescriptors[safe: index] {
+                    return .init(context: context,
+                                 first: firstDescriptor.description,
+                                 second: nil)
+                }
+                return nil
+            }
+            guard firstDescriptor == secondDescriptor else {
+                return .init(context: context,
+                             first: firstDescriptor.description,
+                             second: secondDescriptor.description)
+            }
+            return nil
+        }
+        return result(context: context, differentValues: differentValues)
+    }
+}
+
+private extension PBXBuildPhase {
+    func descriptor() -> BuildPhaseDescriptor {
+        return BuildPhaseDescriptor(name: name(),
+                                    type: type(),
+                                    inputFileListPaths: inputFileListPaths,
+                                    outputFileListPaths: outputFileListPaths,
+                                    runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing)
+    }
+}
+
+private struct BuildPhaseDescriptor: Equatable, CustomStringConvertible {
+    let name: String?
+    let type: BuildPhase?
+    let inputFileListPaths: [String]?
+    let outputFileListPaths: [String]?
+    let runOnlyForDeploymentPostprocessing: Bool
+
+    var description: String {
+        var elements = [String]()
+        elements.append("name = \(name ?? "nil")")
+        elements.append("type = \(type?.rawValue ?? "nil")")
+        elements.append("runOnlyForDeploymentPostprocessing = \(runOnlyForDeploymentPostprocessing)")
+        if let inputFileListPaths = inputFileListPaths {
+            elements.append("inputFileListPaths = \(inputFileListPaths.description)")
+        }
+        if let outputFileListPaths = outputFileListPaths {
+            elements.append("outputFileListPaths = \(outputFileListPaths.description)")
+        }
+        return elements.joined(separator: ", ")
+    }
+}

--- a/Sources/XCDiffCore/Comparator/BuildPhasesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/BuildPhasesComparator.swift
@@ -36,20 +36,14 @@ final class BuildPhasesComparator: Comparator {
         let differentValues: [CompareResult.DifferentValues] = (0 ..< count).compactMap { index in
             let context = "Build Phase \(index + 1)"
             guard let firstDescriptor = firstDescriptors[safe: index] else {
-                if let secondDescriptor = secondDescriptors[safe: index] {
-                    return .init(context: context,
-                                 first: nil,
-                                 second: secondDescriptor.description)
-                }
-                return nil
+                return .init(context: context,
+                             first: nil,
+                             second: secondDescriptors[index].description)
             }
             guard let secondDescriptor = secondDescriptors[safe: index] else {
-                if let firstDescriptor = firstDescriptors[safe: index] {
-                    return .init(context: context,
-                                 first: firstDescriptor.description,
-                                 second: nil)
-                }
-                return nil
+                return .init(context: context,
+                             first: firstDescriptors[index].description,
+                             second: nil)
             }
             guard firstDescriptor == secondDescriptor else {
                 return .init(context: context,

--- a/Sources/XCDiffCore/Comparator/BuildPhasesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/BuildPhasesComparator.swift
@@ -59,7 +59,7 @@ final class BuildPhasesComparator: Comparator {
 private extension PBXBuildPhase {
     func descriptor() -> BuildPhaseDescriptor {
         return BuildPhaseDescriptor(name: name(),
-                                    type: type(),
+                                    type: buildPhase,
                                     inputFileListPaths: inputFileListPaths,
                                     outputFileListPaths: outputFileListPaths,
                                     runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing)
@@ -68,7 +68,7 @@ private extension PBXBuildPhase {
 
 private struct BuildPhaseDescriptor: Equatable, CustomStringConvertible {
     let name: String?
-    let type: BuildPhase?
+    let type: BuildPhase
     let inputFileListPaths: [String]?
     let outputFileListPaths: [String]?
     let runOnlyForDeploymentPostprocessing: Bool
@@ -76,7 +76,7 @@ private struct BuildPhaseDescriptor: Equatable, CustomStringConvertible {
     var description: String {
         var elements = [String]()
         elements.append("name = \(name ?? "nil")")
-        elements.append("type = \(type?.rawValue ?? "nil")")
+        elements.append("type = \(type)")
         elements.append("runOnlyForDeploymentPostprocessing = \(runOnlyForDeploymentPostprocessing)")
         if let inputFileListPaths = inputFileListPaths {
             elements.append("inputFileListPaths = \(inputFileListPaths.description)")

--- a/Sources/XCDiffCore/Comparator/BuildPhasesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/BuildPhasesComparator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Bloomberg Finance L.P.
+// Copyright 2020 Bloomberg Finance L.P.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,57 +32,144 @@ final class BuildPhasesComparator: Comparator {
         let context = ["\"\(first.name)\" target"]
         let firstDescriptors = first.buildPhases.map { $0.descriptor() }
         let secondDescriptors = second.buildPhases.map { $0.descriptor() }
-        let count = max(firstDescriptors.count, secondDescriptors.count)
-        let differentValues: [CompareResult.DifferentValues] = (0 ..< count).compactMap { index in
-            let context = "Build Phase \(index + 1)"
-            guard let firstDescriptor = firstDescriptors[safe: index] else {
-                return .init(context: context,
-                             first: nil,
-                             second: secondDescriptors[index].description)
-            }
-            guard let secondDescriptor = secondDescriptors[safe: index] else {
-                return .init(context: context,
-                             first: firstDescriptors[index].description,
-                             second: nil)
-            }
-            guard firstDescriptor == secondDescriptor else {
-                return .init(context: context,
-                             first: firstDescriptor.description,
-                             second: secondDescriptor.description)
-            }
-            return nil
+        let firstIdentifiers = firstDescriptors.map { $0.identifier }
+        let secondIdentifiers = secondDescriptors.map { $0.identifier }
+        let onlyInFirst = self.onlyInFirst(firstIdentifiers, secondIdentifiers)
+        let onlyInSecond = self.onlyInSecond(firstIdentifiers, secondIdentifiers)
+        let differentValues = self.differentValues(firstDescriptors, secondDescriptors)
+        return result(context: context,
+                      onlyInFirst: onlyInFirst,
+                      onlyInSecond: onlyInSecond,
+                      differentValues: differentValues)
+    }
+
+    private func differentValues(_ first: [BuildPhaseDescriptor],
+                                 _ second: [BuildPhaseDescriptor]) -> [CompareResult.DifferentValues] {
+        return differentOrder(first, second) + differentProperties(first, second)
+    }
+
+    private func differentOrder(_ first: [BuildPhaseDescriptor],
+                                _ second: [BuildPhaseDescriptor]) -> [CompareResult.DifferentValues] {
+        let firstIdentifiers = first.map { $0.identifier }
+        let secondIdentifiers = second.map { $0.identifier }
+        let commonInFirst = self.commonInFirst(firstIdentifiers, secondIdentifiers)
+        let commonInSecond = self.commonInSecond(firstIdentifiers, secondIdentifiers)
+        let count = min(commonInFirst.count, commonInSecond.count)
+        let commonFirstIdentifiers = commonInFirst[0 ..< count]
+        let commonSecondIdentifiers = commonInSecond[0 ..< count]
+        let firstValue = commonFirstIdentifiers.map { $0.description }.joined(separator: ", ")
+        let secondValue = commonSecondIdentifiers.map { $0.description }.joined(separator: ", ")
+        guard commonFirstIdentifiers == commonSecondIdentifiers else {
+            return [CompareResult.DifferentValues(context: "Different order",
+                                                  first: firstValue,
+                                                  second: secondValue)]
         }
-        return result(context: context, differentValues: differentValues)
+        return []
+    }
+
+    private func differentProperties(_ first: [BuildPhaseDescriptor],
+                                     _ second: [BuildPhaseDescriptor]) -> [CompareResult.DifferentValues] {
+        let firstIdentifiers = Set(first.map { $0.identifier })
+        let secondIdentifiers = Set(second.map { $0.identifier })
+        let firstDescriptorsByIdentifier = Dictionary(grouping: first) { $0.identifier }
+        let secondDescriptorsByIdentifier = Dictionary(grouping: second) { $0.identifier }
+        let commonIdentifiers = firstIdentifiers.intersection(secondIdentifiers)
+        return commonIdentifiers.flatMap { identifier -> [CompareResult.DifferentValues] in
+            let firstDescriptors = firstDescriptorsByIdentifier[identifier]!
+            let secondDescriptors = secondDescriptorsByIdentifier[identifier]!
+            let count = min(firstDescriptors.count, secondDescriptors.count)
+            let result: [CompareResult.DifferentValues] = (0 ..< count).compactMap {
+                let firstDescriptor = firstDescriptors[$0]
+                let secondDescriptor = secondDescriptors[$0]
+                guard firstDescriptor == secondDescriptor else {
+                    let identifier = firstDescriptor.identifier.description
+                    let firstProperties = firstDescriptor.properties(compareTo: secondDescriptor)
+                    let secondProperties = secondDescriptor.properties(compareTo: firstDescriptor)
+                    return CompareResult.DifferentValues(context: "Different properties in \"\(identifier)\"",
+                                                         first: firstProperties,
+                                                         second: secondProperties)
+                }
+                return nil
+            }
+            return result
+        }
+    }
+
+    private func onlyInFirst(_ first: [BuildPhaseDescriptor.Identifier],
+                             _ second: [BuildPhaseDescriptor.Identifier]) -> [String] {
+        return second.reduce(first) { acc, value in
+            guard let index = acc.firstIndex(of: value) else {
+                return acc
+            }
+            var result = acc
+            result.remove(at: index)
+            return result
+        }.map { $0.description }
+    }
+
+    private func onlyInSecond(_ first: [BuildPhaseDescriptor.Identifier],
+                              _ second: [BuildPhaseDescriptor.Identifier]) -> [String] {
+        return onlyInFirst(second, first)
+    }
+
+    private func commonInFirst(_ first: [BuildPhaseDescriptor.Identifier],
+                               _ second: [BuildPhaseDescriptor.Identifier]) -> [BuildPhaseDescriptor.Identifier] {
+        var secondIdentifiers = second
+        var result = [BuildPhaseDescriptor.Identifier]()
+        for firstValue in first {
+            guard let index = secondIdentifiers.firstIndex(of: firstValue) else {
+                continue
+            }
+            result.append(firstValue)
+            secondIdentifiers.remove(at: index)
+        }
+        return result
+    }
+
+    private func commonInSecond(_ first: [BuildPhaseDescriptor.Identifier],
+                                _ second: [BuildPhaseDescriptor.Identifier]) -> [BuildPhaseDescriptor.Identifier] {
+        return commonInFirst(second, first)
     }
 }
 
 private extension PBXBuildPhase {
     func descriptor() -> BuildPhaseDescriptor {
-        return BuildPhaseDescriptor(name: name(),
-                                    type: buildPhase,
+        // looks like XcodeProj PBXBuildPhase.name() never returns nil
+        return BuildPhaseDescriptor(identifier: .init(name: name()!, type: buildPhase),
                                     inputFileListPaths: inputFileListPaths,
                                     outputFileListPaths: outputFileListPaths,
                                     runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing)
     }
 }
 
-private struct BuildPhaseDescriptor: Equatable, CustomStringConvertible {
-    let name: String?
-    let type: BuildPhase
+private struct BuildPhaseDescriptor: Equatable {
+    struct Identifier: Hashable, CustomStringConvertible {
+        let name: String
+        let type: BuildPhase
+
+        var description: String {
+            guard name.lowercased() != type.rawValue.lowercased() else {
+                return name
+            }
+            return "\(name) (\(type))"
+        }
+    }
+
+    let identifier: Identifier
     let inputFileListPaths: [String]?
     let outputFileListPaths: [String]?
     let runOnlyForDeploymentPostprocessing: Bool
 
-    var description: String {
+    func properties(compareTo second: BuildPhaseDescriptor) -> String {
         var elements = [String]()
-        elements.append("name = \(name ?? "nil")")
-        elements.append("type = \(type)")
-        elements.append("runOnlyForDeploymentPostprocessing = \(runOnlyForDeploymentPostprocessing)")
-        if let inputFileListPaths = inputFileListPaths {
-            elements.append("inputFileListPaths = \(inputFileListPaths.description)")
+        if runOnlyForDeploymentPostprocessing != second.runOnlyForDeploymentPostprocessing {
+            elements.append("runOnlyForDeploymentPostprocessing = \(runOnlyForDeploymentPostprocessing)")
         }
-        if let outputFileListPaths = outputFileListPaths {
-            elements.append("outputFileListPaths = \(outputFileListPaths.description)")
+        if inputFileListPaths != second.inputFileListPaths {
+            elements.append("inputFileListPaths = \(inputFileListPaths?.description ?? "nil")")
+        }
+        if outputFileListPaths != second.outputFileListPaths {
+            elements.append("outputFileListPaths = \(outputFileListPaths?.description ?? "nil")")
         }
         return elements.joined(separator: ", ")
     }

--- a/Sources/XCDiffCore/ComparatorType.swift
+++ b/Sources/XCDiffCore/ComparatorType.swift
@@ -18,6 +18,7 @@ import Foundation
 
 public enum ComparatorType {
     case fileReferences
+    case buildPhases
     case targets
     case headers
     case sources
@@ -38,6 +39,8 @@ public enum ComparatorType {
         switch self {
         case .fileReferences:
             return FileReferencesComparator()
+        case .buildPhases:
+            return BuildPhasesComparator()
         case .targets:
             return TargetsComparator()
         case .headers:
@@ -66,6 +69,7 @@ public extension Array where Element == ComparatorType {
     static var allAvailableComparators: [ComparatorType] {
         return [
             .fileReferences,
+            .buildPhases,
             .targets,
             .headers,
             .sources,
@@ -81,6 +85,7 @@ public extension Array where Element == ComparatorType {
     static var defaultComparators: [ComparatorType] {
         return [
             .fileReferences,
+            .buildPhases,
             .targets,
             .headers,
             .sources,

--- a/Sources/XCDiffCore/Library/Collections+Extensions.swift
+++ b/Sources/XCDiffCore/Library/Collections+Extensions.swift
@@ -39,3 +39,9 @@ extension Array where Element == String {
         return Set(self)
     }
 }
+
+extension Collection {
+    subscript(safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Sources/XCDiffCore/Library/TargetsHelper.swift
+++ b/Sources/XCDiffCore/Library/TargetsHelper.swift
@@ -20,23 +20,23 @@ import XcodeProj
 
 typealias TargetPair = (first: PBXTarget, second: PBXTarget)
 
-struct SourceDescriptor: Equatable, Hashable {
+struct SourceDescriptor: Hashable {
     let path: String
     let flags: String?
 }
 
-struct HeaderDescriptor: Equatable, Hashable {
+struct HeaderDescriptor: Hashable {
     let path: String
     let attributes: String?
 }
 
-struct DependencyDescriptor: Equatable, Hashable {
+struct DependencyDescriptor: Hashable {
     let name: String?
     let path: String?
     let type: DependencyDescriptorType
 }
 
-struct EmbeddedFrameworksDescriptor: Equatable, Hashable {
+struct EmbeddedFrameworksDescriptor: Hashable {
     let path: String
     let codeSignOnCopy: Bool
 }
@@ -160,6 +160,8 @@ final class TargetsHelper {
             return nil
         }
     }
+
+    // MARK: - Private
 
     private func codeSignAttributes(for file: PBXBuildFile) -> Bool {
         guard let settings = file.settings else {

--- a/Tests/XCDiffCommandTests/CommandsRunnerTests.swift
+++ b/Tests/XCDiffCommandTests/CommandsRunnerTests.swift
@@ -48,6 +48,11 @@ final class CommandsRunnerTests: XCTestCase {
         // Then
         XCTAssertEqual(printer.output, """
         ✅ FILE_REFERENCES
+        ✅ BUILD_PHASES > "MismatchingLibrary" target
+        ✅ BUILD_PHASES > "Project" target
+        ✅ BUILD_PHASES > "ProjectFramework" target
+        ✅ BUILD_PHASES > "ProjectTests" target
+        ✅ BUILD_PHASES > "ProjectUITests" target
         ✅ TARGETS > NATIVE targets
         ✅ TARGETS > AGGREGATE targets
         ✅ HEADERS > "MismatchingLibrary" target

--- a/Tests/XCDiffCoreTests/Comparator/BuildPhasesComparatorTests.swift
+++ b/Tests/XCDiffCoreTests/Comparator/BuildPhasesComparatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Bloomberg Finance L.P.
+// Copyright 2020 Bloomberg Finance L.P.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import Foundation
 @testable import XCDiffCore
 import XCTest
 
+// swiftlint:disable:next type_body_length
 final class BuildPhasesComparatorTests: XCTestCase {
     private var subject: BuildPhasesComparator!
 
@@ -51,7 +52,7 @@ final class BuildPhasesComparatorTests: XCTestCase {
         XCTAssertEqual(actual, [.init(tag: "build_phases", context: ["\"Target1\" target"])])
     }
 
-    func testCompare_whenSameBuildPhasesButDifferentOrder() throws {
+    func testCompare_whenOneBuildPhaseOnlyInFirst() throws {
         // Given
         let first = project()
             .addTarget(name: "Target1", productType: .application) { target in
@@ -63,10 +64,9 @@ final class BuildPhasesComparatorTests: XCTestCase {
             .projectDescriptor()
         let second = project()
             .addTarget(name: "Target1", productType: .application) { target in
-                target.addBuildPhase(.resources) { $0.addBuildFile { $0.setPath("C1.jpeg") } }
                 target.addBuildPhase(.copyFiles(.plugins)) { _ in }
-                target.addBuildPhase(.headers) { $0.addBuildFile { $0.setPath("A1.h") } }
-                target.addBuildPhase(.sources) { $0.addBuildFile { $0.setPath("B1.swift") } }
+                target.addBuildPhase(.sources) { $0.addBuildFile { $0.setPath("B.swift") } }
+                target.addBuildPhase(.resources) { $0.addBuildFile { $0.setPath("C.jpeg") } }
             }
             .projectDescriptor()
 
@@ -77,38 +77,25 @@ final class BuildPhasesComparatorTests: XCTestCase {
         XCTAssertEqual(actual, [
             .init(tag: "build_phases",
                   context: ["\"Target1\" target"],
-                  differentValues: [
-                      .init(context: "Build Phase 1",
-                            first: "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false",
-                            second: "name = Resources, type = Resources, runOnlyForDeploymentPostprocessing = false"),
-                      .init(context: "Build Phase 2",
-                            first: "name = Headers, type = Headers, runOnlyForDeploymentPostprocessing = false",
-                            second: "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false"),
-                      .init(context: "Build Phase 3",
-                            first: "name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false",
-                            second: "name = Headers, type = Headers, runOnlyForDeploymentPostprocessing = false"),
-                      .init(context: "Build Phase 4",
-                            first: "name = Resources, type = Resources, runOnlyForDeploymentPostprocessing = false",
-                            second: "name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false"),
-                  ]),
+                  onlyInFirst: ["Headers"]),
         ])
     }
 
-    func testCompare_whenMissingCopyFilesBuildPhasesInFirst() throws {
+    func testCompare_whenOneBuildPhaseOnlyInSecond() throws {
         // Given
         let first = project()
             .addTarget(name: "Target1", productType: .application) { target in
                 target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.sources) { $0.addBuildFile { $0.setPath("B.swift") } }
+                target.addBuildPhase(.resources) { $0.addBuildFile { $0.setPath("C.jpeg") } }
             }
             .projectDescriptor()
         let second = project()
             .addTarget(name: "Target1", productType: .application) { target in
                 target.addBuildPhase(.copyFiles(.plugins)) { _ in }
-                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
-                target.addBuildPhase(.copyFiles(.init(name: "Custom Copy Files",
-                                                      runOnlyForDeploymentPostprocessing: false,
-                                                      dskSubfolderSpec: nil,
-                                                      dstPath: nil))) { _ in }
+                target.addBuildPhase(.headers) { $0.addBuildFile { $0.setPath("A.h") } }
+                target.addBuildPhase(.sources) { $0.addBuildFile { $0.setPath("B.swift") } }
+                target.addBuildPhase(.resources) { $0.addBuildFile { $0.setPath("C.jpeg") } }
             }
             .projectDescriptor()
 
@@ -119,33 +106,109 @@ final class BuildPhasesComparatorTests: XCTestCase {
         XCTAssertEqual(actual, [
             .init(tag: "build_phases",
                   context: ["\"Target1\" target"],
-                  differentValues: [
-                      .init(context: "Build Phase 2",
-                            first: nil,
-                            second: "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false"),
-                      .init(context: "Build Phase 3",
-                            first: nil,
-                            second:
-                            "name = Custom Copy Files, type = CopyFiles, runOnlyForDeploymentPostprocessing = false"),
-                  ]),
+                  onlyInSecond: ["Headers"]),
         ])
     }
 
-    func testCompare_whenMissingCopyFilesBuildPhasesInSecond() throws {
+    func testCompare_whenTwoBuildPhasesOfSameTypeOnlyInFirstSameOrder() throws {
         // Given
         let first = project()
             .addTarget(name: "Target1", productType: .application) { target in
                 target.addBuildPhase(.copyFiles(.plugins)) { _ in }
-                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
-                target.addBuildPhase(.copyFiles(.init(name: "Custom Copy Files",
-                                                      runOnlyForDeploymentPostprocessing: false,
-                                                      dskSubfolderSpec: nil,
-                                                      dstPath: nil))) { _ in }
+                target.addBuildPhase(.shellScripts) { $0.setName("Shell 1") }
+                target.addBuildPhase(.shellScripts) { $0.setName("Shell 2") }
+                target.addBuildPhase(.shellScripts) { $0.setName("Shell 3") }
             }
             .projectDescriptor()
         let second = project()
             .addTarget(name: "Target1", productType: .application) { target in
                 target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.shellScripts) { $0.setName("Shell 1") }
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first, second, parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [
+            .init(tag: "build_phases",
+                  context: ["\"Target1\" target"],
+                  onlyInFirst: ["Shell 2 (runScript)", "Shell 3 (runScript)"]),
+        ])
+    }
+
+    func testCompare_whenTwoBuildPhasesOfSameTypeOnlyInFirstDifferentOrder() throws {
+        // Given
+        let first = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.shellScripts) { $0.setName("Shell 2") }
+                target.addBuildPhase(.shellScripts) { $0.setName("Shell 3") }
+                target.addBuildPhase(.shellScripts) { $0.setName("Shell 1") }
+            }
+            .projectDescriptor()
+        let second = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.shellScripts) { $0.setName("Shell 1") }
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first, second, parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [
+            .init(tag: "build_phases",
+                  context: ["\"Target1\" target"],
+                  onlyInFirst: ["Shell 2 (runScript)", "Shell 3 (runScript)"]),
+        ])
+    }
+
+    func testCompare_whenSameBuildPhaseDifferentName() throws {
+        // Given
+        let first = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.shellScripts) { $0.setName("Shell A") }
+            }
+            .projectDescriptor()
+        let second = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.shellScripts) { $0.setName("Shell B") }
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first, second, parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [
+            .init(tag: "build_phases",
+                  context: ["\"Target1\" target"],
+                  onlyInFirst: ["Shell A (runScript)"],
+                  onlyInSecond: ["Shell B (runScript)"]),
+        ])
+    }
+
+    func testCompare_whenSameBuildPhasesButDifferentOrder() throws {
+        // Given
+        let first = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.sources) { $0.addBuildFile { $0.setPath("B.swift") } }
+                target.addBuildPhase(.resources) { $0.addBuildFile { $0.setPath("C.jpeg") } }
+                target.addBuildPhase(.headers) { $0.addBuildFile { $0.setPath("A.h") } }
+            }
+            .projectDescriptor()
+        let second = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.headers) { $0.addBuildFile { $0.setPath("A.h") } }
+                target.addBuildPhase(.sources) { $0.addBuildFile { $0.setPath("B.swift") } }
+                target.addBuildPhase(.resources) { $0.addBuildFile { $0.setPath("C.jpeg") } }
             }
             .projectDescriptor()
 
@@ -157,13 +220,9 @@ final class BuildPhasesComparatorTests: XCTestCase {
             .init(tag: "build_phases",
                   context: ["\"Target1\" target"],
                   differentValues: [
-                      .init(context: "Build Phase 2",
-                            first: "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false",
-                            second: nil),
-                      .init(context: "Build Phase 3",
-                            first:
-                            "name = Custom Copy Files, type = CopyFiles, runOnlyForDeploymentPostprocessing = false",
-                            second: nil),
+                      .init(context: "Different order",
+                            first: "CopyFiles, Sources, Resources, Headers",
+                            second: "CopyFiles, Headers, Sources, Resources"),
                   ]),
         ])
     }
@@ -199,16 +258,81 @@ final class BuildPhasesComparatorTests: XCTestCase {
             .init(tag: "build_phases",
                   context: ["\"Target1\" target"],
                   differentValues: [
-                      .init(context: "Build Phase 1",
-                            first: "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false, "
-                                + "inputFileListPaths = [\"input1.txt\", \"input2.txt\", \"input3.txt\"]",
-                            second: "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false, "
-                                + "inputFileListPaths = [\"input1.txt\"]"),
-                      .init(context: "Build Phase 2",
-                            first: "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false, "
-                                + "outputFileListPaths = [\"output1.txt\", \"output2.txt\", \"output3.txt\"]",
-                            second: "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false, "
-                                + "outputFileListPaths = [\"output1.txt\"]"),
+                      .init(context: "Different properties in \"CopyFiles\"",
+                            first: "inputFileListPaths = [\"input1.txt\", \"input2.txt\", \"input3.txt\"]",
+                            second: "inputFileListPaths = [\"input1.txt\"]"),
+                      .init(context: "Different properties in \"CopyFiles\"",
+                            first: "outputFileListPaths = [\"output1.txt\", \"output2.txt\", \"output3.txt\"]",
+                            second: "outputFileListPaths = [\"output1.txt\"]"),
+                  ]),
+        ])
+    }
+
+    func testCompare_whenDifferentOutputInputFileListPathsWithNils() throws {
+        // Given
+        let first = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) {
+                    $0.setInputFileListPaths(["input1.txt", "input2.txt", "input3.txt"])
+                }
+                target.addBuildPhase(.copyFiles(.plugins)) {
+                    $0.setOutputFileListPaths(["output1.txt", "output2.txt", "output3.txt"])
+                }
+            }
+            .projectDescriptor()
+        let second = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first, second, parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [
+            .init(tag: "build_phases",
+                  context: ["\"Target1\" target"],
+                  differentValues: [
+                      .init(context: "Different properties in \"CopyFiles\"",
+                            first: "inputFileListPaths = [\"input1.txt\", \"input2.txt\", \"input3.txt\"]",
+                            second: "inputFileListPaths = nil"),
+                      .init(context: "Different properties in \"CopyFiles\"",
+                            first: "outputFileListPaths = [\"output1.txt\", \"output2.txt\", \"output3.txt\"]",
+                            second: "outputFileListPaths = nil"),
+                  ]),
+        ])
+    }
+
+    func testCompare_whenDifferentRunOnlyForDeploymentPostprocessing() throws {
+        // Given
+        let first = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                let copyBuildPhase = CopyFilesBuildPhase(runOnlyForDeploymentPostprocessing: true,
+                                                         dskSubfolderSpec: .plugins)
+                target.addBuildPhase(.copyFiles(copyBuildPhase)) { _ in }
+            }
+            .projectDescriptor()
+        let second = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                let copyBuildPhase = CopyFilesBuildPhase(runOnlyForDeploymentPostprocessing: false,
+                                                         dskSubfolderSpec: .plugins)
+                target.addBuildPhase(.copyFiles(copyBuildPhase)) { _ in }
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first, second, parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [
+            .init(tag: "build_phases",
+                  context: ["\"Target1\" target"],
+                  differentValues: [
+                      .init(context: "Different properties in \"CopyFiles\"",
+                            first: "runOnlyForDeploymentPostprocessing = true",
+                            second: "runOnlyForDeploymentPostprocessing = false"),
                   ]),
         ])
     }

--- a/Tests/XCDiffCoreTests/Comparator/BuildPhasesComparatorTests.swift
+++ b/Tests/XCDiffCoreTests/Comparator/BuildPhasesComparatorTests.swift
@@ -1,0 +1,133 @@
+//
+// Copyright 2019 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+@testable import XCDiffCore
+import XCTest
+
+final class BuildPhasesComparatorTests: XCTestCase {
+    private var subject: BuildPhasesComparator!
+
+    override func setUp() {
+        subject = BuildPhasesComparator()
+    }
+
+    func testCompare_whenEqualBuildPhases() throws {
+        // Given
+        let first = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.headers) { $0.addBuildFile { $0.setPath("A.h") } }
+                target.addBuildPhase(.sources) { $0.addBuildFile { $0.setPath("B.swift") } }
+                target.addBuildPhase(.resources) { $0.addBuildFile { $0.setPath("C.jpeg") } }
+            }
+            .projectDescriptor()
+        let second = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.headers) { $0.addBuildFile { $0.setPath("A1.h") } }
+                target.addBuildPhase(.sources) { $0.addBuildFile { $0.setPath("B1.swift") } }
+                target.addBuildPhase(.resources) { $0.addBuildFile { $0.setPath("C1.jpeg") } }
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first, second, parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [.init(tag: "build_phases", context: ["\"Target1\" target"])])
+    }
+
+    func testCompare_whenSameBuildPhasesButDifferentOrder() throws {
+        // Given
+        let first = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.headers) { $0.addBuildFile { $0.setPath("A.h") } }
+                target.addBuildPhase(.sources) { $0.addBuildFile { $0.setPath("B.swift") } }
+                target.addBuildPhase(.resources) { $0.addBuildFile { $0.setPath("C.jpeg") } }
+            }
+            .projectDescriptor()
+        let second = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.resources) { $0.addBuildFile { $0.setPath("C1.jpeg") } }
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.headers) { $0.addBuildFile { $0.setPath("A1.h") } }
+                target.addBuildPhase(.sources) { $0.addBuildFile { $0.setPath("B1.swift") } }
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first, second, parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [
+            .init(tag: "build_phases",
+                  context: ["\"Target1\" target"],
+                  differentValues: [
+                      .init(context: "Build Phase 1",
+                            first: "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false",
+                            second: "name = Resources, type = Resources, runOnlyForDeploymentPostprocessing = false"),
+                      .init(context: "Build Phase 2",
+                            first: "name = Headers, type = Headers, runOnlyForDeploymentPostprocessing = false",
+                            second: "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false"),
+                      .init(context: "Build Phase 3",
+                            first: "name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false",
+                            second: "name = Headers, type = Headers, runOnlyForDeploymentPostprocessing = false"),
+                      .init(context: "Build Phase 4",
+                            first: "name = Resources, type = Resources, runOnlyForDeploymentPostprocessing = false",
+                            second: "name = Sources, type = Sources, runOnlyForDeploymentPostprocessing = false"),
+                  ]),
+        ])
+    }
+
+    func testCompare_whenMissingCopyFilesBuildPhase() throws {
+        // Given
+        let first = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.copyFiles(.init(name: "Custom Copy Files",
+                                                      runOnlyForDeploymentPostprocessing: false,
+                                                      dskSubfolderSpec: nil,
+                                                      dstPath: nil))) { _ in }
+            }
+            .projectDescriptor()
+        let second = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first, second, parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [
+            .init(tag: "build_phases",
+                  context: ["\"Target1\" target"],
+                  differentValues: [
+                      .init(context: "Build Phase 2",
+                            first: "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false",
+                            second: nil),
+                      .init(context: "Build Phase 3",
+                            first:
+                            "name = Custom Copy Files, type = CopyFiles, runOnlyForDeploymentPostprocessing = false",
+                            second: nil),
+                  ]),
+        ])
+    }
+}

--- a/Tests/XCDiffCoreTests/Comparator/BuildPhasesComparatorTests.swift
+++ b/Tests/XCDiffCoreTests/Comparator/BuildPhasesComparatorTests.swift
@@ -130,4 +130,49 @@ final class BuildPhasesComparatorTests: XCTestCase {
                   ]),
         ])
     }
+
+    func testCompare_whenDifferentOutputInputFileListPaths() throws {
+        // Given
+        let first = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) {
+                    $0.setInputFileListPaths(["input1.txt", "input2.txt", "input3.txt"])
+                }
+                target.addBuildPhase(.copyFiles(.plugins)) {
+                    $0.setOutputFileListPaths(["output1.txt", "output2.txt", "output3.txt"])
+                }
+            }
+            .projectDescriptor()
+        let second = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) {
+                    $0.setInputFileListPaths(["input1.txt"])
+                }
+                target.addBuildPhase(.copyFiles(.plugins)) {
+                    $0.setOutputFileListPaths(["output1.txt"])
+                }
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first, second, parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [
+            .init(tag: "build_phases",
+                  context: ["\"Target1\" target"],
+                  differentValues: [
+                      .init(context: "Build Phase 1",
+                            first: "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false, "
+                                + "inputFileListPaths = [\"input1.txt\", \"input2.txt\", \"input3.txt\"]",
+                            second: "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false, "
+                                + "inputFileListPaths = [\"input1.txt\"]"),
+                      .init(context: "Build Phase 2",
+                            first: "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false, "
+                                + "outputFileListPaths = [\"output1.txt\", \"output2.txt\", \"output3.txt\"]",
+                            second: "name = CopyFiles, type = CopyFiles, runOnlyForDeploymentPostprocessing = false, "
+                                + "outputFileListPaths = [\"output1.txt\"]"),
+                  ]),
+        ])
+    }
 }

--- a/Tests/XCDiffCoreTests/Helpers/PBXBuildPhaseBuilder.swift
+++ b/Tests/XCDiffCoreTests/Helpers/PBXBuildPhaseBuilder.swift
@@ -20,6 +20,8 @@ import XcodeProj
 final class PBXBuildPhaseBuilder {
     private var buildFiles: [PBXBuildFile] = []
     private var objects: [PBXObject] = []
+    private var inputFileListPaths: [String]?
+    private var outputFileListPaths: [String]?
     private let type: BuildPhase
 
     init(type: BuildPhase) {
@@ -33,6 +35,18 @@ final class PBXBuildPhaseBuilder {
         let (buildFile, buildFileObjects) = builder.build()
         buildFiles.append(buildFile)
         objects.append(contentsOf: buildFileObjects)
+        return self
+    }
+
+    @discardableResult
+    func setInputFileListPaths(_ paths: [String]) -> PBXBuildPhaseBuilder {
+        inputFileListPaths = paths
+        return self
+    }
+
+    @discardableResult
+    func setOutputFileListPaths(_ paths: [String]) -> PBXBuildPhaseBuilder {
+        outputFileListPaths = paths
         return self
     }
 
@@ -55,6 +69,8 @@ final class PBXBuildPhaseBuilder {
                                                 runOnlyForDeploymentPostprocessing: copyBuildPhase
                                                     .runOnlyForDeploymentPostprocessing)
         }
+        buildPhase.inputFileListPaths = inputFileListPaths
+        buildPhase.outputFileListPaths = outputFileListPaths
         return (buildPhase, objects + [buildPhase])
     }
 }

--- a/Tests/XCDiffCoreTests/Helpers/PBXBuildPhaseBuilder.swift
+++ b/Tests/XCDiffCoreTests/Helpers/PBXBuildPhaseBuilder.swift
@@ -47,10 +47,29 @@ final class PBXBuildPhaseBuilder {
             buildPhase = PBXHeadersBuildPhase(files: buildFiles)
         case .frameworks:
             buildPhase = PBXFrameworksBuildPhase(files: buildFiles)
-        case .embedFrameworks:
-            buildPhase = PBXCopyFilesBuildPhase(dstSubfolderSpec: .frameworks,
-                                                files: buildFiles)
+        case let .copyFiles(copyBuildPhase):
+            buildPhase = PBXCopyFilesBuildPhase(dstPath: copyBuildPhase.dstPath,
+                                                dstSubfolderSpec: .from(copyBuildPhase.dskSubfolderSpec),
+                                                name: copyBuildPhase.name,
+                                                files: buildFiles,
+                                                runOnlyForDeploymentPostprocessing: copyBuildPhase
+                                                    .runOnlyForDeploymentPostprocessing)
         }
         return (buildPhase, objects + [buildPhase])
+    }
+}
+
+private extension PBXCopyFilesBuildPhase.SubFolder {
+    static func from(_ spec: DskSubfolderSpec?) -> PBXCopyFilesBuildPhase.SubFolder? {
+        return spec.map {
+            switch $0 {
+            case .frameworks:
+                return .frameworks
+            case .plugins:
+                return .plugins
+            case .resources:
+                return .resources
+            }
+        }
     }
 }

--- a/Tests/XCDiffCoreTests/Helpers/PBXBuildPhaseBuilder.swift
+++ b/Tests/XCDiffCoreTests/Helpers/PBXBuildPhaseBuilder.swift
@@ -18,6 +18,7 @@ import Foundation
 import XcodeProj
 
 final class PBXBuildPhaseBuilder {
+    private var name: String?
     private var buildFiles: [PBXBuildFile] = []
     private var objects: [PBXObject] = []
     private var inputFileListPaths: [String]?
@@ -35,6 +36,12 @@ final class PBXBuildPhaseBuilder {
         let (buildFile, buildFileObjects) = builder.build()
         buildFiles.append(buildFile)
         objects.append(contentsOf: buildFileObjects)
+        return self
+    }
+
+    @discardableResult
+    func setName(_ name: String) -> PBXBuildPhaseBuilder {
+        self.name = name
         return self
     }
 
@@ -61,6 +68,8 @@ final class PBXBuildPhaseBuilder {
             buildPhase = PBXHeadersBuildPhase(files: buildFiles)
         case .frameworks:
             buildPhase = PBXFrameworksBuildPhase(files: buildFiles)
+        case .shellScripts:
+            buildPhase = PBXShellScriptBuildPhase(files: buildFiles, name: name)
         case let .copyFiles(copyBuildPhase):
             buildPhase = PBXCopyFilesBuildPhase(dstPath: copyBuildPhase.dstPath,
                                                 dstSubfolderSpec: .from(copyBuildPhase.dskSubfolderSpec),

--- a/Tests/XCDiffCoreTests/Helpers/PBXNativeTargetBuilder.swift
+++ b/Tests/XCDiffCoreTests/Helpers/PBXNativeTargetBuilder.swift
@@ -43,6 +43,7 @@ enum BuildPhase {
     case sources
     case frameworks
     case resources
+    case shellScripts
     case copyFiles(CopyFilesBuildPhase)
     case headers
 }

--- a/Tests/XCDiffCoreTests/Helpers/PBXNativeTargetBuilder.swift
+++ b/Tests/XCDiffCoreTests/Helpers/PBXNativeTargetBuilder.swift
@@ -23,12 +23,28 @@ struct PBXNativeTargetPrototype {
     let fileElements: [PBXFileElement] // need to be added to the main group
 }
 
-public enum BuildPhase: String {
-    case sources = "Sources"
-    case frameworks = "Frameworks"
-    case resources = "Resources"
-    case embedFrameworks = "EmbedFrameworks"
-    case headers = "Headers"
+enum DskSubfolderSpec {
+    case frameworks
+    case plugins
+    case resources
+}
+
+struct CopyFilesBuildPhase {
+    static let frameworks = CopyFilesBuildPhase(dskSubfolderSpec: .frameworks)
+    static let plugins = CopyFilesBuildPhase(dskSubfolderSpec: .plugins)
+
+    var name: String?
+    var runOnlyForDeploymentPostprocessing: Bool = false
+    var dskSubfolderSpec: DskSubfolderSpec?
+    var dstPath: String?
+}
+
+enum BuildPhase {
+    case sources
+    case frameworks
+    case resources
+    case copyFiles(CopyFilesBuildPhase)
+    case headers
 }
 
 final class PBXNativeTargetBuilder {
@@ -176,7 +192,7 @@ final class PBXNativeTargetBuilder {
 
     @discardableResult
     func addEmbeddedFrameworks(_ embeddedFrameworks: [EmbeddedFrameworksData]) -> PBXNativeTargetBuilder {
-        addBuildPhase(.embedFrameworks) { buildPhaseBuilder in
+        addBuildPhase(.copyFiles(.frameworks)) { buildPhaseBuilder in
             embeddedFrameworks.forEach { embeddedFramework in
                 buildPhaseBuilder.addBuildFile { buildFileBuilder in
                     buildFileBuilder.setPath(embeddedFramework.path)

--- a/Tests/XCDiffCoreTests/Mocks/ComparatorTypeTests.swift
+++ b/Tests/XCDiffCoreTests/Mocks/ComparatorTypeTests.swift
@@ -23,6 +23,7 @@ final class ComperatorTypeTests: XCTestCase {
         // When / Then
         XCTAssertEqual([ComparatorType].allAvailableComparators.map { $0.tag }, [
             "file_references",
+            "build_phases",
             "targets",
             "headers",
             "sources",


### PR DESCRIPTION
Partially resolves: https://github.com/bloomberg/xcdiff/issues/17

**Describe your changes**
Added a new comparator to compare lists of build phases from two projects. The comparison is slightly more complicated to give clear output for most common cases i.e. missing a single build phase in one of the projects, the same build phases but in different order, or different properties in one of the projects.

**Testing performed**
- CI / unit and integration tests
- Copy an existing project, modify list of build phases in the copy, run `xcdiff -p1 <original> -p2 <copy> -g build_phases -v`, make sure all the differences are listed.
