### PR TITLE
Apply more lenient comparison for inputFileListPaths and outputFileListPaths

### DIFF
--- a/Sources/XCDiffCore/Comparator/BuildPhasesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/BuildPhasesComparator.swift
@@ -165,12 +165,19 @@ private struct BuildPhaseDescriptor: Equatable {
         if runOnlyForDeploymentPostprocessing != second.runOnlyForDeploymentPostprocessing {
             elements.append("runOnlyForDeploymentPostprocessing = \(runOnlyForDeploymentPostprocessing)")
         }
-        if inputFileListPaths != second.inputFileListPaths {
+        if inputFileListPaths.valueOrEmpty != second.inputFileListPaths.valueOrEmpty {
             elements.append("inputFileListPaths = \(describe(inputFileListPaths?.description))")
         }
-        if outputFileListPaths != second.outputFileListPaths {
+        if outputFileListPaths.valueOrEmpty != second.outputFileListPaths.valueOrEmpty {
             elements.append("outputFileListPaths = \(describe(outputFileListPaths?.description))")
         }
         return elements.joined(separator: ", ")
+    }
+
+    static func ==(lhs: BuildPhaseDescriptor, rhs: BuildPhaseDescriptor) -> Bool {
+        lhs.identifier == rhs.identifier
+            && lhs.runOnlyForDeploymentPostprocessing == rhs.runOnlyForDeploymentPostprocessing
+            && lhs.inputFileListPaths.valueOrEmpty == rhs.inputFileListPaths.valueOrEmpty
+            && lhs.outputFileListPaths.valueOrEmpty == rhs.outputFileListPaths.valueOrEmpty
     }
 }

--- a/Sources/XCDiffCore/Comparator/BuildPhasesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/BuildPhasesComparator.swift
@@ -174,7 +174,7 @@ private struct BuildPhaseDescriptor: Equatable {
         return elements.joined(separator: ", ")
     }
 
-    static func ==(lhs: BuildPhaseDescriptor, rhs: BuildPhaseDescriptor) -> Bool {
+    static func == (lhs: BuildPhaseDescriptor, rhs: BuildPhaseDescriptor) -> Bool {
         lhs.identifier == rhs.identifier
             && lhs.runOnlyForDeploymentPostprocessing == rhs.runOnlyForDeploymentPostprocessing
             && lhs.inputFileListPaths.valueOrEmpty == rhs.inputFileListPaths.valueOrEmpty

--- a/Sources/XCDiffCore/Comparator/CopyFilesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/CopyFilesComparator.swift
@@ -157,12 +157,12 @@ private struct CopyFilesBuildPhaseDescriptor: Equatable {
                                 first: "\(runOnlyForDeploymentPostprocessing)",
                                 second: "\(second.runOnlyForDeploymentPostprocessing)"))
         }
-        if inputFileListPaths != second.inputFileListPaths {
+        if inputFileListPaths.valueOrEmpty != second.inputFileListPaths.valueOrEmpty {
             result.append(.init(context: "inputFileListPaths",
                                 first: "\(describe(inputFileListPaths))",
                                 second: "\(describe(second.inputFileListPaths))"))
         }
-        if outputFileListPaths != second.outputFileListPaths {
+        if outputFileListPaths.valueOrEmpty != second.outputFileListPaths.valueOrEmpty {
             result.append(.init(context: "outputFileListPaths",
                                 first: "\(describe(outputFileListPaths))",
                                 second: "\(describe(second.outputFileListPaths))"))

--- a/Sources/XCDiffCore/Library/Optional+Extensions.swift
+++ b/Sources/XCDiffCore/Library/Optional+Extensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Bloomberg Finance L.P.
+// Copyright 2020 Bloomberg Finance L.P.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,12 +15,6 @@
 //
 
 import Foundation
-
-extension Optional where Wrapped: Collection {
-    var isNilOrEmpty: Bool {
-        self?.isEmpty ?? true
-    }
-}
 
 // Inspired by http://www.russbishop.net/improving-optionals
 // A type that has an empty value representation, as opposed to `nil`.
@@ -38,7 +32,7 @@ extension Set: EmptyValueRepresentable {
 }
 
 extension Dictionary: EmptyValueRepresentable {
-    public static var emptyValue: Dictionary<Key, Value> { return [:] }
+    public static var emptyValue: [Key: Value] { return [:] }
 }
 
 extension String: EmptyValueRepresentable {

--- a/Sources/XCDiffCore/Library/Optional+Extensions.swift
+++ b/Sources/XCDiffCore/Library/Optional+Extensions.swift
@@ -43,7 +43,7 @@ extension Optional where Wrapped: EmptyValueRepresentable {
     /// If `self == nil` returns the empty value, otherwise returns the value.
     var valueOrEmpty: Wrapped {
         switch self {
-        case .some(let value):
+        case let .some(value):
             return value
         case .none:
             return Wrapped.emptyValue

--- a/Sources/XCDiffCore/Library/Optional+Extensions.swift
+++ b/Sources/XCDiffCore/Library/Optional+Extensions.swift
@@ -1,0 +1,58 @@
+//
+// Copyright 2019 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+extension Optional where Wrapped: Collection {
+    var isNilOrEmpty: Bool {
+        self?.isEmpty ?? true
+    }
+}
+
+// Inspired by http://www.russbishop.net/improving-optionals
+// A type that has an empty value representation, as opposed to `nil`.
+protocol EmptyValueRepresentable {
+    /// Provide the empty value representation of the conforming type.
+    static var emptyValue: Self { get }
+}
+
+extension Array: EmptyValueRepresentable {
+    public static var emptyValue: [Element] { return [] }
+}
+
+extension Set: EmptyValueRepresentable {
+    public static var emptyValue: Set<Element> { return Set() }
+}
+
+extension Dictionary: EmptyValueRepresentable {
+    public static var emptyValue: Dictionary<Key, Value> { return [:] }
+}
+
+extension String: EmptyValueRepresentable {
+    public static var emptyValue: String { return "" }
+}
+
+extension Optional where Wrapped: EmptyValueRepresentable {
+    /// If `self == nil` returns the empty value, otherwise returns the value.
+    var valueOrEmpty: Wrapped {
+        switch self {
+        case .some(let value):
+            return value
+        case .none:
+            return Wrapped.emptyValue
+        }
+    }
+}

--- a/Sources/XCDiffCore/Library/String+Extensions.swift
+++ b/Sources/XCDiffCore/Library/String+Extensions.swift
@@ -19,9 +19,9 @@ import Foundation
 extension String {
     func split(around delimiter: String) -> (String, String?) {
         var start = startIndex
-        while let index = self.index(start, offsetBy: delimiter.count, limitedBy: self.endIndex) {
+        while let index = self.index(start, offsetBy: delimiter.count, limitedBy: endIndex) {
             if self[start ..< index] == delimiter {
-                let leading = self[self.startIndex ..< start]
+                let leading = self[startIndex ..< start]
                 guard index != endIndex else {
                     return (String(leading), "")
                 }

--- a/Tests/XCDiffCoreTests/Comparator/BuildPhasesComparatorTests.swift
+++ b/Tests/XCDiffCoreTests/Comparator/BuildPhasesComparatorTests.swift
@@ -305,6 +305,34 @@ final class BuildPhasesComparatorTests: XCTestCase {
         ])
     }
 
+    func testCompare_whenEmptyEqualsNilInputAndOutpulFileListPaths() throws {
+        // Given
+        let first = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) {
+                    $0.setInputFileListPaths([])
+                }
+                target.addBuildPhase(.copyFiles(.plugins)) {
+                    $0.setOutputFileListPaths([])
+                }
+            }
+            .projectDescriptor()
+        let second = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+                target.addBuildPhase(.copyFiles(.plugins)) { _ in }
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first, second, parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [
+            .init(tag: "build_phases", context: ["\"Target1\" target"]),
+        ])
+    }
+
     func testCompare_whenDifferentRunOnlyForDeploymentPostprocessing() throws {
         // Given
         let first = project()

--- a/Tests/XCDiffCoreTests/Comparator/CopyFilesComparatorTests.swift
+++ b/Tests/XCDiffCoreTests/Comparator/CopyFilesComparatorTests.swift
@@ -311,6 +311,32 @@ final class CopyFilesComparatorTests: XCTestCase {
         ])
     }
 
+    func testCompare_whenEmptyEqualsNilInputAndOutpulFileListPaths() throws {
+        // Given
+        let first = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.frameworks)) { buildPhase in
+                    buildPhase
+                        .setInputFileListPaths([])
+                        .setOutputFileListPaths([])
+                }
+            }
+            .projectDescriptor()
+        let second = project()
+            .addTarget(name: "Target1", productType: .application) { target in
+                target.addBuildPhase(.copyFiles(.frameworks)) { _ in }
+            }
+            .projectDescriptor()
+
+        // When
+        let actual = try subject.compare(first, second, parameters: .all)
+
+        // Then
+        XCTAssertEqual(actual, [
+            .init(tag: "copy_files", context: ["\"Target1\" target", "CopyFiles"]),
+        ])
+    }
+
     func testCompare_whenSameBuildPhaseNameButDifferentDstfolderSpec() throws {
         // Given
         let first = project()


### PR DESCRIPTION
Meaning, nil and empty array might be considered equal.

Issue number of the reported bug or feature request: #50 

**Describe your changes**
When comparing between inputFileListPaths and outputFileListPaths in the copy files or other build phases, the comparators assume that an empty array equals a nil array.

**Testing performed**
Check added tests.

**Additional context**
Instead of having the property as `[String]` instead of an optional one, I preferred to keep the original types of the properties. This has the downside of using the `valueOrEmpty` property when comparing values.

Interestingly, there was the need to override the `Equatable` protocol only for `BuildPhaseDescriptor` but not for `CopyFilesBuildPhaseDescriptor`.
