### PR TITLE
Better error descriptions when errors don’t conform to LocalizedError

### DIFF
--- a/Sources/XCDiffCommand/CommandRunner.swift
+++ b/Sources/XCDiffCommand/CommandRunner.swift
@@ -289,7 +289,11 @@ public final class CommandRunner {
         case let error as ArgumentParserError:
             return (1, error.description)
         default:
-            return (1, error.localizedDescription)
+            if let lError = error as? LocalizedError {
+                return (1, lError.errorDescription ?? lError.localizedDescription)
+            }
+
+            return (1, String(describing: error))
         }
     }
 


### PR DESCRIPTION
When a PBXProjError was thrown, xcdiff would print insufficient information, like the following:

ERROR: The operation couldn’t be completed. (XcodeProj.PBXProjError error 1.)

With this change, it prints now:

ERROR: Cannot calculate full path for file element “../Some/Path/SomeProject.xcodeproj" in source root: "/Users/SomeUser/Documents/Project/app"

If the error conforms to LocalizedError, then we try printing the errorDescription (according to the docs: A localized message describing what error occurred.), and if it’s nil, Error’s localizedDescription.

Otherwise, juse use String(describing:), which in turn prints the `description` in case Error conforms to CustomStringConvertible.