### PR TITLE
Display values for settings present only in one project

### DIFF
--- a/CommandTests/Generated/p1_p2_Project_target_console_format_verbose.2.ba4ce842.md
+++ b/CommandTests/Generated/p1_p2_Project_target_console_format_verbose.2.ba4ce842.md
@@ -98,7 +98,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ✅ SETTINGS > Root project > "Release" configuration > Base configuration
@@ -106,7 +106,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
@@ -122,7 +122,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):
@@ -137,7 +137,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):

--- a/CommandTests/Generated/p1_p2_Project_target_json_format.2.1b44ee6e.md
+++ b/CommandTests/Generated/p1_p2_Project_target_json_format.2.1b44ee6e.md
@@ -206,7 +206,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -240,7 +240,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -282,7 +282,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   },
@@ -320,7 +320,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   },

--- a/CommandTests/Generated/p1_p2_Project_target_json_format_verbose.2.bcad53ce.md
+++ b/CommandTests/Generated/p1_p2_Project_target_json_format_verbose.2.bcad53ce.md
@@ -206,7 +206,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -240,7 +240,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -282,7 +282,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   },
@@ -320,7 +320,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   },

--- a/CommandTests/Generated/p1_p2_Project_target_markdown_format_verbose.2.f582a13e.md
+++ b/CommandTests/Generated/p1_p2_Project_target_markdown_format_verbose.2.f582a13e.md
@@ -120,7 +120,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `CUSTOM_SETTGING_1`
+  - `CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL`
 
 
 
@@ -132,7 +132,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `CUSTOM_SETTGING_1`
+  - `CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL`
 
 
 
@@ -152,7 +152,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES`
 
 
 ### ⚠️  Value mismatch (1):
@@ -171,7 +171,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES`
 
 
 ### ⚠️  Value mismatch (1):

--- a/CommandTests/Generated/p1_p2_Project_target_verbose.2.6f518e43.md
+++ b/CommandTests/Generated/p1_p2_Project_target_verbose.2.6f518e43.md
@@ -98,7 +98,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ✅ SETTINGS > Root project > "Release" configuration > Base configuration
@@ -106,7 +106,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
@@ -122,7 +122,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):
@@ -137,7 +137,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):

--- a/CommandTests/Generated/p1_p2_console_format_verbose.2.40a241bd.md
+++ b/CommandTests/Generated/p1_p2_console_format_verbose.2.40a241bd.md
@@ -201,7 +201,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ✅ SETTINGS > Root project > "Release" configuration > Base configuration
@@ -209,7 +209,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
@@ -217,24 +217,24 @@
 
 ⚠️  Only in first (1):
 
-  • OTHER_LDFLAGS
+  • OTHER_LDFLAGS = -ObjC
 
 
 ⚠️  Only in second (13):
 
-  • CLANG_ENABLE_MODULES
-  • CURRENT_PROJECT_VERSION
-  • DEFINES_MODULE
-  • DYLIB_COMPATIBILITY_VERSION
-  • DYLIB_CURRENT_VERSION
-  • DYLIB_INSTALL_NAME_BASE
-  • INFOPLIST_FILE
-  • INSTALL_PATH
-  • LD_RUNPATH_SEARCH_PATHS
-  • PRODUCT_BUNDLE_IDENTIFIER
-  • SWIFT_OPTIMIZATION_LEVEL
-  • VERSIONING_SYSTEM
-  • VERSION_INFO_PREFIX
+  • CLANG_ENABLE_MODULES = YES
+  • CURRENT_PROJECT_VERSION = 1
+  • DEFINES_MODULE = YES
+  • DYLIB_COMPATIBILITY_VERSION = 1
+  • DYLIB_CURRENT_VERSION = 1
+  • DYLIB_INSTALL_NAME_BASE = @rpath
+  • INFOPLIST_FILE = MismatchingLibrary/MismatchingLibrary-Info.plist
+  • INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks
+  • LD_RUNPATH_SEARCH_PATHS = ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]
+  • PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary
+  • SWIFT_OPTIMIZATION_LEVEL = -Onone
+  • VERSIONING_SYSTEM = apple-generic
+  • VERSION_INFO_PREFIX = 
 
 
 ⚠️  Value mismatch (1):
@@ -249,23 +249,23 @@
 
 ⚠️  Only in first (1):
 
-  • OTHER_LDFLAGS
+  • OTHER_LDFLAGS = -ObjC
 
 
 ⚠️  Only in second (12):
 
-  • CLANG_ENABLE_MODULES
-  • CURRENT_PROJECT_VERSION
-  • DEFINES_MODULE
-  • DYLIB_COMPATIBILITY_VERSION
-  • DYLIB_CURRENT_VERSION
-  • DYLIB_INSTALL_NAME_BASE
-  • INFOPLIST_FILE
-  • INSTALL_PATH
-  • LD_RUNPATH_SEARCH_PATHS
-  • PRODUCT_BUNDLE_IDENTIFIER
-  • VERSIONING_SYSTEM
-  • VERSION_INFO_PREFIX
+  • CLANG_ENABLE_MODULES = YES
+  • CURRENT_PROJECT_VERSION = 1
+  • DEFINES_MODULE = YES
+  • DYLIB_COMPATIBILITY_VERSION = 1
+  • DYLIB_CURRENT_VERSION = 1
+  • DYLIB_INSTALL_NAME_BASE = @rpath
+  • INFOPLIST_FILE = MismatchingLibrary/MismatchingLibrary-Info.plist
+  • INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks
+  • LD_RUNPATH_SEARCH_PATHS = ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]
+  • PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary
+  • VERSIONING_SYSTEM = apple-generic
+  • VERSION_INFO_PREFIX = 
 
 
 ⚠️  Value mismatch (1):
@@ -288,7 +288,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):
@@ -303,7 +303,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):

--- a/CommandTests/Generated/p1_p2_json_format.2.e54c06ce.md
+++ b/CommandTests/Generated/p1_p2_json_format.2.e54c06ce.md
@@ -520,7 +520,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -554,7 +554,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -589,22 +589,22 @@
       }
     ],
     "onlyInFirst" : [
-      "OTHER_LDFLAGS"
+      "OTHER_LDFLAGS = -ObjC"
     ],
     "onlyInSecond" : [
-      "CLANG_ENABLE_MODULES",
-      "CURRENT_PROJECT_VERSION",
-      "DEFINES_MODULE",
-      "DYLIB_COMPATIBILITY_VERSION",
-      "DYLIB_CURRENT_VERSION",
-      "DYLIB_INSTALL_NAME_BASE",
-      "INFOPLIST_FILE",
-      "INSTALL_PATH",
-      "LD_RUNPATH_SEARCH_PATHS",
-      "PRODUCT_BUNDLE_IDENTIFIER",
-      "SWIFT_OPTIMIZATION_LEVEL",
-      "VERSIONING_SYSTEM",
-      "VERSION_INFO_PREFIX"
+      "CLANG_ENABLE_MODULES = YES",
+      "CURRENT_PROJECT_VERSION = 1",
+      "DEFINES_MODULE = YES",
+      "DYLIB_COMPATIBILITY_VERSION = 1",
+      "DYLIB_CURRENT_VERSION = 1",
+      "DYLIB_INSTALL_NAME_BASE = @rpath",
+      "INFOPLIST_FILE = MismatchingLibrary\/MismatchingLibrary-Info.plist",
+      "INSTALL_PATH = $(LOCAL_LIBRARY_DIR)\/Frameworks",
+      "LD_RUNPATH_SEARCH_PATHS = [\"$(inherited)\", \"@executable_path\/Frameworks\", \"@loader_path\/Frameworks\"]",
+      "PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary",
+      "SWIFT_OPTIMIZATION_LEVEL = -Onone",
+      "VERSIONING_SYSTEM = apple-generic",
+      "VERSION_INFO_PREFIX = "
     ],
     "tag" : "settings"
   },
@@ -639,21 +639,21 @@
       }
     ],
     "onlyInFirst" : [
-      "OTHER_LDFLAGS"
+      "OTHER_LDFLAGS = -ObjC"
     ],
     "onlyInSecond" : [
-      "CLANG_ENABLE_MODULES",
-      "CURRENT_PROJECT_VERSION",
-      "DEFINES_MODULE",
-      "DYLIB_COMPATIBILITY_VERSION",
-      "DYLIB_CURRENT_VERSION",
-      "DYLIB_INSTALL_NAME_BASE",
-      "INFOPLIST_FILE",
-      "INSTALL_PATH",
-      "LD_RUNPATH_SEARCH_PATHS",
-      "PRODUCT_BUNDLE_IDENTIFIER",
-      "VERSIONING_SYSTEM",
-      "VERSION_INFO_PREFIX"
+      "CLANG_ENABLE_MODULES = YES",
+      "CURRENT_PROJECT_VERSION = 1",
+      "DEFINES_MODULE = YES",
+      "DYLIB_COMPATIBILITY_VERSION = 1",
+      "DYLIB_CURRENT_VERSION = 1",
+      "DYLIB_INSTALL_NAME_BASE = @rpath",
+      "INFOPLIST_FILE = MismatchingLibrary\/MismatchingLibrary-Info.plist",
+      "INSTALL_PATH = $(LOCAL_LIBRARY_DIR)\/Frameworks",
+      "LD_RUNPATH_SEARCH_PATHS = [\"$(inherited)\", \"@executable_path\/Frameworks\", \"@loader_path\/Frameworks\"]",
+      "PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary",
+      "VERSIONING_SYSTEM = apple-generic",
+      "VERSION_INFO_PREFIX = "
     ],
     "tag" : "settings"
   },
@@ -695,7 +695,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   },
@@ -733,7 +733,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   },

--- a/CommandTests/Generated/p1_p2_json_format_verbose.2.0e0a3eb6.md
+++ b/CommandTests/Generated/p1_p2_json_format_verbose.2.0e0a3eb6.md
@@ -520,7 +520,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -554,7 +554,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -589,22 +589,22 @@
       }
     ],
     "onlyInFirst" : [
-      "OTHER_LDFLAGS"
+      "OTHER_LDFLAGS = -ObjC"
     ],
     "onlyInSecond" : [
-      "CLANG_ENABLE_MODULES",
-      "CURRENT_PROJECT_VERSION",
-      "DEFINES_MODULE",
-      "DYLIB_COMPATIBILITY_VERSION",
-      "DYLIB_CURRENT_VERSION",
-      "DYLIB_INSTALL_NAME_BASE",
-      "INFOPLIST_FILE",
-      "INSTALL_PATH",
-      "LD_RUNPATH_SEARCH_PATHS",
-      "PRODUCT_BUNDLE_IDENTIFIER",
-      "SWIFT_OPTIMIZATION_LEVEL",
-      "VERSIONING_SYSTEM",
-      "VERSION_INFO_PREFIX"
+      "CLANG_ENABLE_MODULES = YES",
+      "CURRENT_PROJECT_VERSION = 1",
+      "DEFINES_MODULE = YES",
+      "DYLIB_COMPATIBILITY_VERSION = 1",
+      "DYLIB_CURRENT_VERSION = 1",
+      "DYLIB_INSTALL_NAME_BASE = @rpath",
+      "INFOPLIST_FILE = MismatchingLibrary\/MismatchingLibrary-Info.plist",
+      "INSTALL_PATH = $(LOCAL_LIBRARY_DIR)\/Frameworks",
+      "LD_RUNPATH_SEARCH_PATHS = [\"$(inherited)\", \"@executable_path\/Frameworks\", \"@loader_path\/Frameworks\"]",
+      "PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary",
+      "SWIFT_OPTIMIZATION_LEVEL = -Onone",
+      "VERSIONING_SYSTEM = apple-generic",
+      "VERSION_INFO_PREFIX = "
     ],
     "tag" : "settings"
   },
@@ -639,21 +639,21 @@
       }
     ],
     "onlyInFirst" : [
-      "OTHER_LDFLAGS"
+      "OTHER_LDFLAGS = -ObjC"
     ],
     "onlyInSecond" : [
-      "CLANG_ENABLE_MODULES",
-      "CURRENT_PROJECT_VERSION",
-      "DEFINES_MODULE",
-      "DYLIB_COMPATIBILITY_VERSION",
-      "DYLIB_CURRENT_VERSION",
-      "DYLIB_INSTALL_NAME_BASE",
-      "INFOPLIST_FILE",
-      "INSTALL_PATH",
-      "LD_RUNPATH_SEARCH_PATHS",
-      "PRODUCT_BUNDLE_IDENTIFIER",
-      "VERSIONING_SYSTEM",
-      "VERSION_INFO_PREFIX"
+      "CLANG_ENABLE_MODULES = YES",
+      "CURRENT_PROJECT_VERSION = 1",
+      "DEFINES_MODULE = YES",
+      "DYLIB_COMPATIBILITY_VERSION = 1",
+      "DYLIB_CURRENT_VERSION = 1",
+      "DYLIB_INSTALL_NAME_BASE = @rpath",
+      "INFOPLIST_FILE = MismatchingLibrary\/MismatchingLibrary-Info.plist",
+      "INSTALL_PATH = $(LOCAL_LIBRARY_DIR)\/Frameworks",
+      "LD_RUNPATH_SEARCH_PATHS = [\"$(inherited)\", \"@executable_path\/Frameworks\", \"@loader_path\/Frameworks\"]",
+      "PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary",
+      "VERSIONING_SYSTEM = apple-generic",
+      "VERSION_INFO_PREFIX = "
     ],
     "tag" : "settings"
   },
@@ -695,7 +695,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   },
@@ -733,7 +733,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   },

--- a/CommandTests/Generated/p1_p2_markdown_format_verbose.2.ac528bab.md
+++ b/CommandTests/Generated/p1_p2_markdown_format_verbose.2.ac528bab.md
@@ -263,7 +263,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `CUSTOM_SETTGING_1`
+  - `CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL`
 
 
 
@@ -275,7 +275,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `CUSTOM_SETTGING_1`
+  - `CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL`
 
 
 
@@ -287,24 +287,24 @@
 
 ### ⚠️  Only in first (1):
 
-  - `OTHER_LDFLAGS`
+  - `OTHER_LDFLAGS = -ObjC`
 
 
 ### ⚠️  Only in second (13):
 
-  - `CLANG_ENABLE_MODULES`
-  - `CURRENT_PROJECT_VERSION`
-  - `DEFINES_MODULE`
-  - `DYLIB_COMPATIBILITY_VERSION`
-  - `DYLIB_CURRENT_VERSION`
-  - `DYLIB_INSTALL_NAME_BASE`
-  - `INFOPLIST_FILE`
-  - `INSTALL_PATH`
-  - `LD_RUNPATH_SEARCH_PATHS`
-  - `PRODUCT_BUNDLE_IDENTIFIER`
-  - `SWIFT_OPTIMIZATION_LEVEL`
-  - `VERSIONING_SYSTEM`
-  - `VERSION_INFO_PREFIX`
+  - `CLANG_ENABLE_MODULES = YES`
+  - `CURRENT_PROJECT_VERSION = 1`
+  - `DEFINES_MODULE = YES`
+  - `DYLIB_COMPATIBILITY_VERSION = 1`
+  - `DYLIB_CURRENT_VERSION = 1`
+  - `DYLIB_INSTALL_NAME_BASE = @rpath`
+  - `INFOPLIST_FILE = MismatchingLibrary/MismatchingLibrary-Info.plist`
+  - `INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks`
+  - `LD_RUNPATH_SEARCH_PATHS = ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]`
+  - `PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary`
+  - `SWIFT_OPTIMIZATION_LEVEL = -Onone`
+  - `VERSIONING_SYSTEM = apple-generic`
+  - `VERSION_INFO_PREFIX = `
 
 
 ### ⚠️  Value mismatch (1):
@@ -323,23 +323,23 @@
 
 ### ⚠️  Only in first (1):
 
-  - `OTHER_LDFLAGS`
+  - `OTHER_LDFLAGS = -ObjC`
 
 
 ### ⚠️  Only in second (12):
 
-  - `CLANG_ENABLE_MODULES`
-  - `CURRENT_PROJECT_VERSION`
-  - `DEFINES_MODULE`
-  - `DYLIB_COMPATIBILITY_VERSION`
-  - `DYLIB_CURRENT_VERSION`
-  - `DYLIB_INSTALL_NAME_BASE`
-  - `INFOPLIST_FILE`
-  - `INSTALL_PATH`
-  - `LD_RUNPATH_SEARCH_PATHS`
-  - `PRODUCT_BUNDLE_IDENTIFIER`
-  - `VERSIONING_SYSTEM`
-  - `VERSION_INFO_PREFIX`
+  - `CLANG_ENABLE_MODULES = YES`
+  - `CURRENT_PROJECT_VERSION = 1`
+  - `DEFINES_MODULE = YES`
+  - `DYLIB_COMPATIBILITY_VERSION = 1`
+  - `DYLIB_CURRENT_VERSION = 1`
+  - `DYLIB_INSTALL_NAME_BASE = @rpath`
+  - `INFOPLIST_FILE = MismatchingLibrary/MismatchingLibrary-Info.plist`
+  - `INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks`
+  - `LD_RUNPATH_SEARCH_PATHS = ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]`
+  - `PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary`
+  - `VERSIONING_SYSTEM = apple-generic`
+  - `VERSION_INFO_PREFIX = `
 
 
 ### ⚠️  Value mismatch (1):
@@ -366,7 +366,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES`
 
 
 ### ⚠️  Value mismatch (1):
@@ -385,7 +385,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES`
 
 
 ### ⚠️  Value mismatch (1):

--- a/CommandTests/Generated/p1_p2_settings_tag_Project_target_console_format_verbose.2.60fa85f8.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_Project_target_console_format_verbose.2.60fa85f8.md
@@ -21,7 +21,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ✅ SETTINGS > Root project > "Release" configuration > Base configuration
@@ -29,7 +29,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
@@ -45,7 +45,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):
@@ -60,7 +60,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):

--- a/CommandTests/Generated/p1_p2_settings_tag_Project_target_json_format.2.63c69b62.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_Project_target_json_format.2.63c69b62.md
@@ -43,7 +43,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -77,7 +77,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -119,7 +119,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   },
@@ -157,7 +157,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   }

--- a/CommandTests/Generated/p1_p2_settings_tag_Project_target_json_format_verbose.2.59e64a35.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_Project_target_json_format_verbose.2.59e64a35.md
@@ -43,7 +43,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -77,7 +77,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -119,7 +119,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   },
@@ -157,7 +157,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   }

--- a/CommandTests/Generated/p1_p2_settings_tag_Project_target_markdown_format_verbose.2.7eb42f94.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_Project_target_markdown_format_verbose.2.7eb42f94.md
@@ -25,7 +25,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `CUSTOM_SETTGING_1`
+  - `CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL`
 
 
 
@@ -37,7 +37,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `CUSTOM_SETTGING_1`
+  - `CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL`
 
 
 
@@ -57,7 +57,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES`
 
 
 ### ⚠️  Value mismatch (1):
@@ -76,7 +76,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES`
 
 
 ### ⚠️  Value mismatch (1):

--- a/CommandTests/Generated/p1_p2_settings_tag_Project_target_verbose.2.23efff72.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_Project_target_verbose.2.23efff72.md
@@ -21,7 +21,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ✅ SETTINGS > Root project > "Release" configuration > Base configuration
@@ -29,7 +29,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ❌ SETTINGS > "Project" target > "Debug" configuration > Base configuration
@@ -45,7 +45,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):
@@ -60,7 +60,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):

--- a/CommandTests/Generated/p1_p2_settings_tag_console_format_verbose.2.6dad29ce.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_console_format_verbose.2.6dad29ce.md
@@ -21,7 +21,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ✅ SETTINGS > Root project > "Release" configuration > Base configuration
@@ -29,7 +29,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
@@ -37,24 +37,24 @@
 
 ⚠️  Only in first (1):
 
-  • OTHER_LDFLAGS
+  • OTHER_LDFLAGS = -ObjC
 
 
 ⚠️  Only in second (13):
 
-  • CLANG_ENABLE_MODULES
-  • CURRENT_PROJECT_VERSION
-  • DEFINES_MODULE
-  • DYLIB_COMPATIBILITY_VERSION
-  • DYLIB_CURRENT_VERSION
-  • DYLIB_INSTALL_NAME_BASE
-  • INFOPLIST_FILE
-  • INSTALL_PATH
-  • LD_RUNPATH_SEARCH_PATHS
-  • PRODUCT_BUNDLE_IDENTIFIER
-  • SWIFT_OPTIMIZATION_LEVEL
-  • VERSIONING_SYSTEM
-  • VERSION_INFO_PREFIX
+  • CLANG_ENABLE_MODULES = YES
+  • CURRENT_PROJECT_VERSION = 1
+  • DEFINES_MODULE = YES
+  • DYLIB_COMPATIBILITY_VERSION = 1
+  • DYLIB_CURRENT_VERSION = 1
+  • DYLIB_INSTALL_NAME_BASE = @rpath
+  • INFOPLIST_FILE = MismatchingLibrary/MismatchingLibrary-Info.plist
+  • INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks
+  • LD_RUNPATH_SEARCH_PATHS = ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]
+  • PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary
+  • SWIFT_OPTIMIZATION_LEVEL = -Onone
+  • VERSIONING_SYSTEM = apple-generic
+  • VERSION_INFO_PREFIX = 
 
 
 ⚠️  Value mismatch (1):
@@ -69,23 +69,23 @@
 
 ⚠️  Only in first (1):
 
-  • OTHER_LDFLAGS
+  • OTHER_LDFLAGS = -ObjC
 
 
 ⚠️  Only in second (12):
 
-  • CLANG_ENABLE_MODULES
-  • CURRENT_PROJECT_VERSION
-  • DEFINES_MODULE
-  • DYLIB_COMPATIBILITY_VERSION
-  • DYLIB_CURRENT_VERSION
-  • DYLIB_INSTALL_NAME_BASE
-  • INFOPLIST_FILE
-  • INSTALL_PATH
-  • LD_RUNPATH_SEARCH_PATHS
-  • PRODUCT_BUNDLE_IDENTIFIER
-  • VERSIONING_SYSTEM
-  • VERSION_INFO_PREFIX
+  • CLANG_ENABLE_MODULES = YES
+  • CURRENT_PROJECT_VERSION = 1
+  • DEFINES_MODULE = YES
+  • DYLIB_COMPATIBILITY_VERSION = 1
+  • DYLIB_CURRENT_VERSION = 1
+  • DYLIB_INSTALL_NAME_BASE = @rpath
+  • INFOPLIST_FILE = MismatchingLibrary/MismatchingLibrary-Info.plist
+  • INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks
+  • LD_RUNPATH_SEARCH_PATHS = ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]
+  • PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary
+  • VERSIONING_SYSTEM = apple-generic
+  • VERSION_INFO_PREFIX = 
 
 
 ⚠️  Value mismatch (1):
@@ -108,7 +108,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):
@@ -123,7 +123,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):

--- a/CommandTests/Generated/p1_p2_settings_tag_json_format.2.c77fc477.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_json_format.2.c77fc477.md
@@ -43,7 +43,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -77,7 +77,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -112,22 +112,22 @@
       }
     ],
     "onlyInFirst" : [
-      "OTHER_LDFLAGS"
+      "OTHER_LDFLAGS = -ObjC"
     ],
     "onlyInSecond" : [
-      "CLANG_ENABLE_MODULES",
-      "CURRENT_PROJECT_VERSION",
-      "DEFINES_MODULE",
-      "DYLIB_COMPATIBILITY_VERSION",
-      "DYLIB_CURRENT_VERSION",
-      "DYLIB_INSTALL_NAME_BASE",
-      "INFOPLIST_FILE",
-      "INSTALL_PATH",
-      "LD_RUNPATH_SEARCH_PATHS",
-      "PRODUCT_BUNDLE_IDENTIFIER",
-      "SWIFT_OPTIMIZATION_LEVEL",
-      "VERSIONING_SYSTEM",
-      "VERSION_INFO_PREFIX"
+      "CLANG_ENABLE_MODULES = YES",
+      "CURRENT_PROJECT_VERSION = 1",
+      "DEFINES_MODULE = YES",
+      "DYLIB_COMPATIBILITY_VERSION = 1",
+      "DYLIB_CURRENT_VERSION = 1",
+      "DYLIB_INSTALL_NAME_BASE = @rpath",
+      "INFOPLIST_FILE = MismatchingLibrary\/MismatchingLibrary-Info.plist",
+      "INSTALL_PATH = $(LOCAL_LIBRARY_DIR)\/Frameworks",
+      "LD_RUNPATH_SEARCH_PATHS = [\"$(inherited)\", \"@executable_path\/Frameworks\", \"@loader_path\/Frameworks\"]",
+      "PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary",
+      "SWIFT_OPTIMIZATION_LEVEL = -Onone",
+      "VERSIONING_SYSTEM = apple-generic",
+      "VERSION_INFO_PREFIX = "
     ],
     "tag" : "settings"
   },
@@ -162,21 +162,21 @@
       }
     ],
     "onlyInFirst" : [
-      "OTHER_LDFLAGS"
+      "OTHER_LDFLAGS = -ObjC"
     ],
     "onlyInSecond" : [
-      "CLANG_ENABLE_MODULES",
-      "CURRENT_PROJECT_VERSION",
-      "DEFINES_MODULE",
-      "DYLIB_COMPATIBILITY_VERSION",
-      "DYLIB_CURRENT_VERSION",
-      "DYLIB_INSTALL_NAME_BASE",
-      "INFOPLIST_FILE",
-      "INSTALL_PATH",
-      "LD_RUNPATH_SEARCH_PATHS",
-      "PRODUCT_BUNDLE_IDENTIFIER",
-      "VERSIONING_SYSTEM",
-      "VERSION_INFO_PREFIX"
+      "CLANG_ENABLE_MODULES = YES",
+      "CURRENT_PROJECT_VERSION = 1",
+      "DEFINES_MODULE = YES",
+      "DYLIB_COMPATIBILITY_VERSION = 1",
+      "DYLIB_CURRENT_VERSION = 1",
+      "DYLIB_INSTALL_NAME_BASE = @rpath",
+      "INFOPLIST_FILE = MismatchingLibrary\/MismatchingLibrary-Info.plist",
+      "INSTALL_PATH = $(LOCAL_LIBRARY_DIR)\/Frameworks",
+      "LD_RUNPATH_SEARCH_PATHS = [\"$(inherited)\", \"@executable_path\/Frameworks\", \"@loader_path\/Frameworks\"]",
+      "PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary",
+      "VERSIONING_SYSTEM = apple-generic",
+      "VERSION_INFO_PREFIX = "
     ],
     "tag" : "settings"
   },
@@ -218,7 +218,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   },
@@ -256,7 +256,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   },

--- a/CommandTests/Generated/p1_p2_settings_tag_json_format_verbose.2.bd3b2234.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_json_format_verbose.2.bd3b2234.md
@@ -43,7 +43,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -77,7 +77,7 @@
 
     ],
     "onlyInSecond" : [
-      "CUSTOM_SETTGING_1"
+      "CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL"
     ],
     "tag" : "settings"
   },
@@ -112,22 +112,22 @@
       }
     ],
     "onlyInFirst" : [
-      "OTHER_LDFLAGS"
+      "OTHER_LDFLAGS = -ObjC"
     ],
     "onlyInSecond" : [
-      "CLANG_ENABLE_MODULES",
-      "CURRENT_PROJECT_VERSION",
-      "DEFINES_MODULE",
-      "DYLIB_COMPATIBILITY_VERSION",
-      "DYLIB_CURRENT_VERSION",
-      "DYLIB_INSTALL_NAME_BASE",
-      "INFOPLIST_FILE",
-      "INSTALL_PATH",
-      "LD_RUNPATH_SEARCH_PATHS",
-      "PRODUCT_BUNDLE_IDENTIFIER",
-      "SWIFT_OPTIMIZATION_LEVEL",
-      "VERSIONING_SYSTEM",
-      "VERSION_INFO_PREFIX"
+      "CLANG_ENABLE_MODULES = YES",
+      "CURRENT_PROJECT_VERSION = 1",
+      "DEFINES_MODULE = YES",
+      "DYLIB_COMPATIBILITY_VERSION = 1",
+      "DYLIB_CURRENT_VERSION = 1",
+      "DYLIB_INSTALL_NAME_BASE = @rpath",
+      "INFOPLIST_FILE = MismatchingLibrary\/MismatchingLibrary-Info.plist",
+      "INSTALL_PATH = $(LOCAL_LIBRARY_DIR)\/Frameworks",
+      "LD_RUNPATH_SEARCH_PATHS = [\"$(inherited)\", \"@executable_path\/Frameworks\", \"@loader_path\/Frameworks\"]",
+      "PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary",
+      "SWIFT_OPTIMIZATION_LEVEL = -Onone",
+      "VERSIONING_SYSTEM = apple-generic",
+      "VERSION_INFO_PREFIX = "
     ],
     "tag" : "settings"
   },
@@ -162,21 +162,21 @@
       }
     ],
     "onlyInFirst" : [
-      "OTHER_LDFLAGS"
+      "OTHER_LDFLAGS = -ObjC"
     ],
     "onlyInSecond" : [
-      "CLANG_ENABLE_MODULES",
-      "CURRENT_PROJECT_VERSION",
-      "DEFINES_MODULE",
-      "DYLIB_COMPATIBILITY_VERSION",
-      "DYLIB_CURRENT_VERSION",
-      "DYLIB_INSTALL_NAME_BASE",
-      "INFOPLIST_FILE",
-      "INSTALL_PATH",
-      "LD_RUNPATH_SEARCH_PATHS",
-      "PRODUCT_BUNDLE_IDENTIFIER",
-      "VERSIONING_SYSTEM",
-      "VERSION_INFO_PREFIX"
+      "CLANG_ENABLE_MODULES = YES",
+      "CURRENT_PROJECT_VERSION = 1",
+      "DEFINES_MODULE = YES",
+      "DYLIB_COMPATIBILITY_VERSION = 1",
+      "DYLIB_CURRENT_VERSION = 1",
+      "DYLIB_INSTALL_NAME_BASE = @rpath",
+      "INFOPLIST_FILE = MismatchingLibrary\/MismatchingLibrary-Info.plist",
+      "INSTALL_PATH = $(LOCAL_LIBRARY_DIR)\/Frameworks",
+      "LD_RUNPATH_SEARCH_PATHS = [\"$(inherited)\", \"@executable_path\/Frameworks\", \"@loader_path\/Frameworks\"]",
+      "PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary",
+      "VERSIONING_SYSTEM = apple-generic",
+      "VERSION_INFO_PREFIX = "
     ],
     "tag" : "settings"
   },
@@ -218,7 +218,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   },
@@ -256,7 +256,7 @@
 
     ],
     "onlyInSecond" : [
-      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES"
+      "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES"
     ],
     "tag" : "settings"
   },

--- a/CommandTests/Generated/p1_p2_settings_tag_markdown_format_verbose.2.ed874e8d.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_markdown_format_verbose.2.ed874e8d.md
@@ -25,7 +25,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `CUSTOM_SETTGING_1`
+  - `CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL`
 
 
 
@@ -37,7 +37,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `CUSTOM_SETTGING_1`
+  - `CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL`
 
 
 
@@ -49,24 +49,24 @@
 
 ### ⚠️  Only in first (1):
 
-  - `OTHER_LDFLAGS`
+  - `OTHER_LDFLAGS = -ObjC`
 
 
 ### ⚠️  Only in second (13):
 
-  - `CLANG_ENABLE_MODULES`
-  - `CURRENT_PROJECT_VERSION`
-  - `DEFINES_MODULE`
-  - `DYLIB_COMPATIBILITY_VERSION`
-  - `DYLIB_CURRENT_VERSION`
-  - `DYLIB_INSTALL_NAME_BASE`
-  - `INFOPLIST_FILE`
-  - `INSTALL_PATH`
-  - `LD_RUNPATH_SEARCH_PATHS`
-  - `PRODUCT_BUNDLE_IDENTIFIER`
-  - `SWIFT_OPTIMIZATION_LEVEL`
-  - `VERSIONING_SYSTEM`
-  - `VERSION_INFO_PREFIX`
+  - `CLANG_ENABLE_MODULES = YES`
+  - `CURRENT_PROJECT_VERSION = 1`
+  - `DEFINES_MODULE = YES`
+  - `DYLIB_COMPATIBILITY_VERSION = 1`
+  - `DYLIB_CURRENT_VERSION = 1`
+  - `DYLIB_INSTALL_NAME_BASE = @rpath`
+  - `INFOPLIST_FILE = MismatchingLibrary/MismatchingLibrary-Info.plist`
+  - `INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks`
+  - `LD_RUNPATH_SEARCH_PATHS = ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]`
+  - `PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary`
+  - `SWIFT_OPTIMIZATION_LEVEL = -Onone`
+  - `VERSIONING_SYSTEM = apple-generic`
+  - `VERSION_INFO_PREFIX = `
 
 
 ### ⚠️  Value mismatch (1):
@@ -85,23 +85,23 @@
 
 ### ⚠️  Only in first (1):
 
-  - `OTHER_LDFLAGS`
+  - `OTHER_LDFLAGS = -ObjC`
 
 
 ### ⚠️  Only in second (12):
 
-  - `CLANG_ENABLE_MODULES`
-  - `CURRENT_PROJECT_VERSION`
-  - `DEFINES_MODULE`
-  - `DYLIB_COMPATIBILITY_VERSION`
-  - `DYLIB_CURRENT_VERSION`
-  - `DYLIB_INSTALL_NAME_BASE`
-  - `INFOPLIST_FILE`
-  - `INSTALL_PATH`
-  - `LD_RUNPATH_SEARCH_PATHS`
-  - `PRODUCT_BUNDLE_IDENTIFIER`
-  - `VERSIONING_SYSTEM`
-  - `VERSION_INFO_PREFIX`
+  - `CLANG_ENABLE_MODULES = YES`
+  - `CURRENT_PROJECT_VERSION = 1`
+  - `DEFINES_MODULE = YES`
+  - `DYLIB_COMPATIBILITY_VERSION = 1`
+  - `DYLIB_CURRENT_VERSION = 1`
+  - `DYLIB_INSTALL_NAME_BASE = @rpath`
+  - `INFOPLIST_FILE = MismatchingLibrary/MismatchingLibrary-Info.plist`
+  - `INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks`
+  - `LD_RUNPATH_SEARCH_PATHS = ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]`
+  - `PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary`
+  - `VERSIONING_SYSTEM = apple-generic`
+  - `VERSION_INFO_PREFIX = `
 
 
 ### ⚠️  Value mismatch (1):
@@ -128,7 +128,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES`
 
 
 ### ⚠️  Value mismatch (1):
@@ -147,7 +147,7 @@
 
 ### ⚠️  Only in second (1):
 
-  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`
+  - `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES`
 
 
 ### ⚠️  Value mismatch (1):

--- a/CommandTests/Generated/p1_p2_settings_tag_verbose.2.97d9bb79.md
+++ b/CommandTests/Generated/p1_p2_settings_tag_verbose.2.97d9bb79.md
@@ -21,7 +21,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ✅ SETTINGS > Root project > "Release" configuration > Base configuration
@@ -29,7 +29,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
@@ -37,24 +37,24 @@
 
 ⚠️  Only in first (1):
 
-  • OTHER_LDFLAGS
+  • OTHER_LDFLAGS = -ObjC
 
 
 ⚠️  Only in second (13):
 
-  • CLANG_ENABLE_MODULES
-  • CURRENT_PROJECT_VERSION
-  • DEFINES_MODULE
-  • DYLIB_COMPATIBILITY_VERSION
-  • DYLIB_CURRENT_VERSION
-  • DYLIB_INSTALL_NAME_BASE
-  • INFOPLIST_FILE
-  • INSTALL_PATH
-  • LD_RUNPATH_SEARCH_PATHS
-  • PRODUCT_BUNDLE_IDENTIFIER
-  • SWIFT_OPTIMIZATION_LEVEL
-  • VERSIONING_SYSTEM
-  • VERSION_INFO_PREFIX
+  • CLANG_ENABLE_MODULES = YES
+  • CURRENT_PROJECT_VERSION = 1
+  • DEFINES_MODULE = YES
+  • DYLIB_COMPATIBILITY_VERSION = 1
+  • DYLIB_CURRENT_VERSION = 1
+  • DYLIB_INSTALL_NAME_BASE = @rpath
+  • INFOPLIST_FILE = MismatchingLibrary/MismatchingLibrary-Info.plist
+  • INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks
+  • LD_RUNPATH_SEARCH_PATHS = ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]
+  • PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary
+  • SWIFT_OPTIMIZATION_LEVEL = -Onone
+  • VERSIONING_SYSTEM = apple-generic
+  • VERSION_INFO_PREFIX = 
 
 
 ⚠️  Value mismatch (1):
@@ -69,23 +69,23 @@
 
 ⚠️  Only in first (1):
 
-  • OTHER_LDFLAGS
+  • OTHER_LDFLAGS = -ObjC
 
 
 ⚠️  Only in second (12):
 
-  • CLANG_ENABLE_MODULES
-  • CURRENT_PROJECT_VERSION
-  • DEFINES_MODULE
-  • DYLIB_COMPATIBILITY_VERSION
-  • DYLIB_CURRENT_VERSION
-  • DYLIB_INSTALL_NAME_BASE
-  • INFOPLIST_FILE
-  • INSTALL_PATH
-  • LD_RUNPATH_SEARCH_PATHS
-  • PRODUCT_BUNDLE_IDENTIFIER
-  • VERSIONING_SYSTEM
-  • VERSION_INFO_PREFIX
+  • CLANG_ENABLE_MODULES = YES
+  • CURRENT_PROJECT_VERSION = 1
+  • DEFINES_MODULE = YES
+  • DYLIB_COMPATIBILITY_VERSION = 1
+  • DYLIB_CURRENT_VERSION = 1
+  • DYLIB_INSTALL_NAME_BASE = @rpath
+  • INFOPLIST_FILE = MismatchingLibrary/MismatchingLibrary-Info.plist
+  • INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks
+  • LD_RUNPATH_SEARCH_PATHS = ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]
+  • PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary
+  • VERSIONING_SYSTEM = apple-generic
+  • VERSION_INFO_PREFIX = 
 
 
 ⚠️  Value mismatch (1):
@@ -108,7 +108,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):
@@ -123,7 +123,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):

--- a/CommandTests/Generated/p1_p2_verbose.2.fe666557.md
+++ b/CommandTests/Generated/p1_p2_verbose.2.fe666557.md
@@ -201,7 +201,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ✅ SETTINGS > Root project > "Release" configuration > Base configuration
@@ -209,7 +209,7 @@
 
 ⚠️  Only in second (1):
 
-  • CUSTOM_SETTGING_1
+  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
 
 
 ✅ SETTINGS > "MismatchingLibrary" target > "Debug" configuration > Base configuration
@@ -217,24 +217,24 @@
 
 ⚠️  Only in first (1):
 
-  • OTHER_LDFLAGS
+  • OTHER_LDFLAGS = -ObjC
 
 
 ⚠️  Only in second (13):
 
-  • CLANG_ENABLE_MODULES
-  • CURRENT_PROJECT_VERSION
-  • DEFINES_MODULE
-  • DYLIB_COMPATIBILITY_VERSION
-  • DYLIB_CURRENT_VERSION
-  • DYLIB_INSTALL_NAME_BASE
-  • INFOPLIST_FILE
-  • INSTALL_PATH
-  • LD_RUNPATH_SEARCH_PATHS
-  • PRODUCT_BUNDLE_IDENTIFIER
-  • SWIFT_OPTIMIZATION_LEVEL
-  • VERSIONING_SYSTEM
-  • VERSION_INFO_PREFIX
+  • CLANG_ENABLE_MODULES = YES
+  • CURRENT_PROJECT_VERSION = 1
+  • DEFINES_MODULE = YES
+  • DYLIB_COMPATIBILITY_VERSION = 1
+  • DYLIB_CURRENT_VERSION = 1
+  • DYLIB_INSTALL_NAME_BASE = @rpath
+  • INFOPLIST_FILE = MismatchingLibrary/MismatchingLibrary-Info.plist
+  • INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks
+  • LD_RUNPATH_SEARCH_PATHS = ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]
+  • PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary
+  • SWIFT_OPTIMIZATION_LEVEL = -Onone
+  • VERSIONING_SYSTEM = apple-generic
+  • VERSION_INFO_PREFIX = 
 
 
 ⚠️  Value mismatch (1):
@@ -249,23 +249,23 @@
 
 ⚠️  Only in first (1):
 
-  • OTHER_LDFLAGS
+  • OTHER_LDFLAGS = -ObjC
 
 
 ⚠️  Only in second (12):
 
-  • CLANG_ENABLE_MODULES
-  • CURRENT_PROJECT_VERSION
-  • DEFINES_MODULE
-  • DYLIB_COMPATIBILITY_VERSION
-  • DYLIB_CURRENT_VERSION
-  • DYLIB_INSTALL_NAME_BASE
-  • INFOPLIST_FILE
-  • INSTALL_PATH
-  • LD_RUNPATH_SEARCH_PATHS
-  • PRODUCT_BUNDLE_IDENTIFIER
-  • VERSIONING_SYSTEM
-  • VERSION_INFO_PREFIX
+  • CLANG_ENABLE_MODULES = YES
+  • CURRENT_PROJECT_VERSION = 1
+  • DEFINES_MODULE = YES
+  • DYLIB_COMPATIBILITY_VERSION = 1
+  • DYLIB_CURRENT_VERSION = 1
+  • DYLIB_INSTALL_NAME_BASE = @rpath
+  • INFOPLIST_FILE = MismatchingLibrary/MismatchingLibrary-Info.plist
+  • INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks
+  • LD_RUNPATH_SEARCH_PATHS = ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]
+  • PRODUCT_BUNDLE_IDENTIFIER = com.bloomberg.xcdiff.Project.MismatchingLibrary
+  • VERSIONING_SYSTEM = apple-generic
+  • VERSION_INFO_PREFIX = 
 
 
 ⚠️  Value mismatch (1):
@@ -288,7 +288,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):
@@ -303,7 +303,7 @@
 
 ⚠️  Only in second (1):
 
-  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES
+  • ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 
 ⚠️  Value mismatch (1):

--- a/Sources/XCDiffCore/Library/SettingsHelper.swift
+++ b/Sources/XCDiffCore/Library/SettingsHelper.swift
@@ -25,8 +25,8 @@ class SettingsHelper {
         let firstKeys = Array(first.keys)
         let secondKeys = Array(second.keys)
         let commonKeys = firstKeys.commonSorted(secondKeys)
-        let onlyInFirst = firstKeys.subtractingAndSorted(secondKeys)
-        let onlyInSecond = secondKeys.subtractingAndSorted(firstKeys)
+        let onlyInFirst = firstKeys.subtractingAndSorted(secondKeys).map { keyAndValue($0, buildSettings: first) }
+        let onlyInSecond = secondKeys.subtractingAndSorted(firstKeys).map { keyAndValue($0, buildSettings: second) }
 
         // we attempt to ignore differences that are a result of different project names
         let firstProjectName = first["PROJECT_NAME"] as? String
@@ -55,6 +55,10 @@ class SettingsHelper {
     }
 
     // MARK: - Private
+
+    private func keyAndValue(_ key: String, buildSettings: BuildSettings) -> String {
+        return "\(key) = \(buildSettings[key] ?? "nil")"
+    }
 
     private func stringFromBuildSetting(_ buildSetting: Any?) throws -> String {
         // try to unwrap

--- a/Tests/XCDiffCoreTests/Comparator/ResolvedSettingsComparatorTests.swift
+++ b/Tests/XCDiffCoreTests/Comparator/ResolvedSettingsComparatorTests.swift
@@ -177,7 +177,7 @@ final class ResolvedSettingsComparatorTests: XCTestCase {
         XCTAssertEqual(actual, [
             .init(tag: "resolved_settings",
                   context: ["\"Target1\" target", "\"Debug\" configuration", "Values"],
-                  onlyInFirst: ["TARGETED_DEVICE_FAMILY", "TARGETNAME"]),
+                  onlyInFirst: ["TARGETED_DEVICE_FAMILY = 1,2", "TARGETNAME = Target1"]),
         ])
     }
 
@@ -212,7 +212,7 @@ final class ResolvedSettingsComparatorTests: XCTestCase {
         XCTAssertEqual(actual, [
             .init(tag: "resolved_settings",
                   context: ["\"Target1\" target", "\"Debug\" configuration", "Values"],
-                  onlyInSecond: ["TARGETED_DEVICE_FAMILY", "TARGETNAME"]),
+                  onlyInSecond: ["TARGETED_DEVICE_FAMILY = 1,2", "TARGETNAME = Target1"]),
         ])
     }
 

--- a/Tests/XCDiffCoreTests/Comparator/SettingsComparatorTests.swift
+++ b/Tests/XCDiffCoreTests/Comparator/SettingsComparatorTests.swift
@@ -131,8 +131,8 @@ final class SettingsComparatorTests: XCTestCase {
                   context: ["Root project", "\"Release\" configuration", "Base configuration"]),
             .init(tag: "settings",
                   context: ["Root project", "\"Release\" configuration", "Values"],
-                  onlyInFirst: ["B"],
-                  onlyInSecond: ["C"],
+                  onlyInFirst: ["B = B_VALUE"],
+                  onlyInSecond: ["C = C_VALUE"],
                   differentValues: [.init(context: "A", first: "A_VALUE_1", second: "A_VALUE_2")]),
         ])
     }
@@ -250,8 +250,8 @@ final class SettingsComparatorTests: XCTestCase {
                   context: ["\"Target\" target", "\"Release\" configuration", "Base configuration"]),
             .init(tag: "settings",
                   context: ["\"Target\" target", "\"Release\" configuration", "Values"],
-                  onlyInFirst: ["B"],
-                  onlyInSecond: ["C"],
+                  onlyInFirst: ["B = B_VALUE"],
+                  onlyInSecond: ["C = C_VALUE"],
                   differentValues: [.init(context: "A", first: "A_VALUE_1", second: "A_VALUE_2")]),
         ])
     }
@@ -330,8 +330,8 @@ final class SettingsComparatorTests: XCTestCase {
                   context: ["\"Target\" target", "\"Debug\" configuration", "Base configuration"]),
             .init(tag: "settings",
                   context: ["\"Target\" target", "\"Debug\" configuration", "Values"],
-                  onlyInFirst: ["DEBUG_B"],
-                  onlyInSecond: ["DEBUG_C"],
+                  onlyInFirst: ["DEBUG_B = B_VALUE"],
+                  onlyInSecond: ["DEBUG_C = C_VALUE"],
                   differentValues: [.init(context: "DEBUG_A", first: "A_VALUE_1", second: "A_VALUE_2")]),
         ])
     }


### PR DESCRIPTION
Resolves: https://github.com/bloomberg/xcdiff/issues/51

**Describe your changes**
Extended the output of `settings` and `resolved_settings` comparators to include setting values.

**Testing performed**
- CI
- Go to `Fixtures` and run `xcdiff -g settings -t Project -v`, ensure setting values are displayed in "Only in..." sections, i.e.

```
⚠️  Only in second (1):

  • CUSTOM_SETTGING_1 = CS_1_PROJECT_LEVEL
```