### PR TITLE
Extend --list command output to show which comparators do not run by default

### DIFF
--- a/CommandTests/Generated/list.0.a330395c.md
+++ b/CommandTests/Generated/list.0.a330395c.md
@@ -8,19 +8,22 @@
 
 # Expected output
 ```
-  COMPARTOR TAG                | DEFAULT  
-------------------------------------------
-- FILE_REFERENCES              | Yes
-- BUILD_PHASES                 | Yes
-- COPY_FILES                   | Yes
-- TARGETS                      | Yes
-- HEADERS                      | Yes
-- SOURCES                      | Yes
-- RESOURCES                    | Yes
-- CONFIGURATIONS               | Yes
-- SETTINGS                     | Yes
-- RESOLVED_SETTINGS            | No
-- SOURCE_TREES                 | Yes
-- LINKED_DEPENDENCIES          | Yes
+The following list shows all available comparator tags along with their default
+inclusion status when tags aren't explicitly specified.
+
+  COMPARTOR TAG                  | INCLUDED  
+-----------------------------------------------
+- FILE_REFERENCES                | Yes
+- BUILD_PHASES                   | Yes
+- COPY_FILES                     | Yes
+- TARGETS                        | Yes
+- HEADERS                        | Yes
+- SOURCES                        | Yes
+- RESOURCES                      | Yes
+- CONFIGURATIONS                 | Yes
+- SETTINGS                       | Yes
+- RESOLVED_SETTINGS              | No
+- SOURCE_TREES                   | Yes
+- LINKED_DEPENDENCIES            | Yes
 
 ```

--- a/CommandTests/Generated/list.0.a330395c.md
+++ b/CommandTests/Generated/list.0.a330395c.md
@@ -8,17 +8,19 @@
 
 # Expected output
 ```
-- FILE_REFERENCES
-- BUILD_PHASES
-- COPY_FILES
-- TARGETS
-- HEADERS
-- SOURCES
-- RESOURCES
-- CONFIGURATIONS
-- SETTINGS
-- RESOLVED_SETTINGS
-- SOURCE_TREES
-- LINKED_DEPENDENCIES
+  COMPARTOR TAG                | DEFAULT  
+------------------------------------------
+- FILE_REFERENCES              | Yes
+- BUILD_PHASES                 | Yes
+- COPY_FILES                   | Yes
+- TARGETS                      | Yes
+- HEADERS                      | Yes
+- SOURCES                      | Yes
+- RESOURCES                    | Yes
+- CONFIGURATIONS               | Yes
+- SETTINGS                     | Yes
+- RESOLVED_SETTINGS            | No
+- SOURCE_TREES                 | Yes
+- LINKED_DEPENDENCIES          | Yes
 
 ```

--- a/Sources/XCDiffCommand/CommandRunner.swift
+++ b/Sources/XCDiffCommand/CommandRunner.swift
@@ -148,17 +148,26 @@ public final class CommandRunner {
             printer.text("No available comparators")
             return 0
         }
-        let nameTitleWidth = 30
-        let defaultTitleWidth = 9
-        let nameTitle = "  COMPARTOR TAG"
-        let defaultTitle = "DEFAULT"
+        let nameColumnWidth = 30
+        let includedColumnWidth = 10
         let columnSeparator = " | "
-        printer.text("\(nameTitle.padding(toLength: nameTitleWidth, withPad: " ", startingAt: 0))"
+        let padding = "  "
+        let separatorLength = 2 * padding.count + nameColumnWidth + columnSeparator.count + includedColumnWidth
+        let separator = String(repeating: "-", count: separatorLength)
+
+        printer.text("""
+        The following list shows all available comparator tags along with their default
+        inclusion status when tags aren't explicitly specified.
+
+        """)
+        printer.text(padding
+            + "COMPARTOR TAG".padding(toLength: nameColumnWidth, withPad: " ", startingAt: 0)
             + columnSeparator
-            + "\(defaultTitle.padding(toLength: defaultTitleWidth, withPad: " ", startingAt: 0))")
-        printer.text(String(repeating: "-", count: nameTitleWidth + columnSeparator.count + defaultTitleWidth))
+            + "INCLUDED".padding(toLength: includedColumnWidth, withPad: " ", startingAt: 0))
+        printer.text(separator)
         let output = allAvailableComparators
-            .map { "- \($0.displayName)".padding(toLength: nameTitleWidth, withPad: " ", startingAt: 0)
+            .map { "- "
+                + $0.displayName.padding(toLength: nameColumnWidth, withPad: " ", startingAt: 0)
                 + columnSeparator
                 + (defaultComparatorsTags.contains($0.tag) ? "Yes" : "No")
             }

--- a/Sources/XCDiffCommand/CommandRunner.swift
+++ b/Sources/XCDiffCommand/CommandRunner.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+// swiftlint:disable type_body_length
 import Basic
 import Foundation
 import PathKit
@@ -141,14 +142,27 @@ public final class CommandRunner {
     }
 
     private func runPrintAvailableOperators() -> Int32 {
-        let comparators = [ComparatorType].allAvailableComparators
-        guard !comparators.isEmpty else {
+        let defaultComparatorsTags = Set([ComparatorType].defaultComparators.map { $0.tag })
+        let allAvailableComparators = [ComparatorType].allAvailableComparators
+        guard !allAvailableComparators.isEmpty else {
             printer.text("No available comparators")
             return 0
         }
-        let output = "- " + comparators
-            .map { $0.displayName }
-            .joined(separator: "\n- ")
+        let nameTitleWidth = 30
+        let defaultTitleWidth = 9
+        let nameTitle = "  COMPARTOR TAG"
+        let defaultTitle = "DEFAULT"
+        let columnSeparator = " | "
+        printer.text("\(nameTitle.padding(toLength: nameTitleWidth, withPad: " ", startingAt: 0))"
+            + columnSeparator
+            + "\(defaultTitle.padding(toLength: defaultTitleWidth, withPad: " ", startingAt: 0))")
+        printer.text(String(repeating: "-", count: nameTitleWidth + columnSeparator.count + defaultTitleWidth))
+        let output = allAvailableComparators
+            .map { "- \($0.displayName)".padding(toLength: nameTitleWidth, withPad: " ", startingAt: 0)
+                + columnSeparator
+                + (defaultComparatorsTags.contains($0.tag) ? "Yes" : "No")
+            }
+            .joined(separator: "\n")
         printer.text(output)
         return 0
     }
@@ -367,3 +381,5 @@ enum CommandError: LocalizedError {
         }
     }
 }
+
+// swiftlint:enable type_body_length


### PR DESCRIPTION
Resolves https://github.com/bloomberg/xcdiff/issues/49

**Testing performed**
- CI
- Run `xcdiff --list`, ensure all except `RESOLVED_SETTINGS` comparators are listed with default value `Yes`. 
