### PR TITLE
Use -json xcodebuild option when extracting resolved settings

### DIFF
--- a/Tests/XCDiffCoreTests/Comparator/ResolvedSettingsComparatorTests.swift
+++ b/Tests/XCDiffCoreTests/Comparator/ResolvedSettingsComparatorTests.swift
@@ -459,8 +459,8 @@ final class ResolvedSettingsComparatorTests: XCTestCase {
         // When / Then
         XCTAssertThrowsError(try subject.compare(first, second, parameters: .all)) { error in
             XCTAssertEqual(error.localizedDescription,
-                           "Cannot extract build settings from the project, invalid json output of xcodebuild command " +
-                               "(project = /projectDirPath, target = Target1, configuration = Debug)")
+                           "Cannot extract build settings from the project, invalid json output of xcodebuild " +
+                               "command (project = /projectDirPath, target = Target1, configuration = Debug)")
         }
     }
 }

--- a/Tests/XCDiffCoreTests/Comparator/ResolvedSettingsComparatorTests.swift
+++ b/Tests/XCDiffCoreTests/Comparator/ResolvedSettingsComparatorTests.swift
@@ -18,6 +18,7 @@ import Foundation
 @testable import XCDiffCore
 import XCTest
 
+// swiftlint:disable file_length
 // swiftlint:disable:next type_body_length
 final class ResolvedSettingsComparatorTests: XCTestCase {
     private var subject: ResolvedSettingsComparator!
@@ -37,6 +38,7 @@ final class ResolvedSettingsComparatorTests: XCTestCase {
         XCTAssertEqual(subject.tag, "resolved_settings")
     }
 
+    // swiftlint:disable:next function_body_length
     func testCompare_whenNoDifference() throws {
         // Given
         let first = project(name: "P1")
@@ -50,16 +52,30 @@ final class ResolvedSettingsComparatorTests: XCTestCase {
 
         system.mockExecuteResults = [
             """
-                TAPI_VERIFY_MODE = ErrorsOnly
-                TARGETED_DEVICE_FAMILY = 1,2
-                TARGETNAME = Target1
-                PROJECT_NAME = P1
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "TAPI_VERIFY_MODE": "ErrorsOnly",
+                        "TARGETED_DEVICE_FAMILY": "1,2",
+                        "TARGETNAME": "Target1",
+                        "PROJECT_NAME": "P1"
+                    }
+                }
+            ]
             """,
             """
-                TAPI_VERIFY_MODE = ErrorsOnly
-                TARGETED_DEVICE_FAMILY = 1,2
-                TARGETNAME = Target1
-                PROJECT_NAME = P1_NEW
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "TAPI_VERIFY_MODE": "ErrorsOnly",
+                        "TARGETED_DEVICE_FAMILY": "1,2",
+                        "TARGETNAME": "Target1",
+                        "PROJECT_NAME": "P1_NEW"
+                    }
+                }
+            ]
             """,
         ]
 
@@ -72,12 +88,14 @@ final class ResolvedSettingsComparatorTests: XCTestCase {
              "-project", "/projectDirPath",
              "-target", "Target1",
              "-config", "Debug",
-             "-showBuildSettings"],
+             "-showBuildSettings",
+             "-json"],
             ["/usr/bin/xcrun", "xcodebuild",
              "-project", "/projectDirPath",
              "-target", "Target1",
              "-config", "Debug",
-             "-showBuildSettings"],
+             "-showBuildSettings",
+             "-json"],
         ])
         XCTAssertEqual(actual, [
             .init(tag: "resolved_settings",
@@ -97,14 +115,28 @@ final class ResolvedSettingsComparatorTests: XCTestCase {
 
         system.mockExecuteResults = [
             """
-                TAPI_VERIFY_MODE = ErrorsOnly
-                PROJECT_NAME = P1
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "TAPI_VERIFY_MODE": "ErrorsOnly",
+                        "PROJECT_NAME": "P1"
+                    }
+                }
+            ]
             """,
             """
-                TAPI_VERIFY_MODE = ErrorsOnly
-                TARGETED_DEVICE_FAMILY = 1,2
-                TARGETNAME = Target1
-                PROJECT_NAME = P1_NEW
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "TAPI_VERIFY_MODE": "ErrorsOnly",
+                        "TARGETED_DEVICE_FAMILY": "1,2",
+                        "TARGETNAME": "Target1",
+                        "PROJECT_NAME": "P1_NEW"
+                    }
+                }
+            ]
             """,
         ]
 
@@ -128,14 +160,28 @@ final class ResolvedSettingsComparatorTests: XCTestCase {
 
         system.mockExecuteResults = [
             """
-                TAPI_VERIFY_MODE = ErrorsOnly
-                TARGETED_DEVICE_FAMILY = 1,2
-                TARGETNAME = Target1
-                PROJECT_NAME = P1
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "TAPI_VERIFY_MODE": "ErrorsOnly",
+                        "TARGETED_DEVICE_FAMILY": "1,2",
+                        "TARGETNAME": "Target1",
+                        "PROJECT_NAME": "P1"
+                    }
+                }
+            ]
             """,
             """
-                TAPI_VERIFY_MODE = ErrorsOnly
-                PROJECT_NAME = P1_NEW
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "TAPI_VERIFY_MODE": "ErrorsOnly",
+                        "PROJECT_NAME": "P1_NEW"
+                    }
+                }
+            ]
             """,
         ]
 
@@ -159,14 +205,28 @@ final class ResolvedSettingsComparatorTests: XCTestCase {
 
         system.mockExecuteResults = [
             """
-                TAPI_VERIFY_MODE = ErrorsOnly
-                TARGETED_DEVICE_FAMILY = 1,2
-                TARGETNAME = Target1
-                PROJECT_NAME = P1
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "TAPI_VERIFY_MODE": "ErrorsOnly",
+                        "TARGETED_DEVICE_FAMILY": "1,2",
+                        "TARGETNAME": "Target1",
+                        "PROJECT_NAME": "P1"
+                    }
+                }
+            ]
             """,
             """
-                TAPI_VERIFY_MODE = ErrorsOnly
-                PROJECT_NAME = P1_NEW
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "TAPI_VERIFY_MODE": "ErrorsOnly",
+                        "PROJECT_NAME": "P1_NEW"
+                    }
+                }
+            ]
             """,
         ]
 
@@ -194,14 +254,28 @@ final class ResolvedSettingsComparatorTests: XCTestCase {
 
         system.mockExecuteResults = [
             """
-                TAPI_VERIFY_MODE = ErrorsOnly
-                PROJECT_NAME = P1
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "TAPI_VERIFY_MODE": "ErrorsOnly",
+                        "PROJECT_NAME": "P1"
+                    }
+                }
+            ]
             """,
             """
-                TAPI_VERIFY_MODE = ErrorsOnly
-                TARGETED_DEVICE_FAMILY = 1,2
-                TARGETNAME = Target1
-                PROJECT_NAME = P1_NEW
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "TAPI_VERIFY_MODE": "ErrorsOnly",
+                        "TARGETED_DEVICE_FAMILY": "1,2",
+                        "TARGETNAME": "Target1",
+                        "PROJECT_NAME": "P1_NEW"
+                    }
+                }
+            ]
             """,
         ]
 
@@ -229,12 +303,26 @@ final class ResolvedSettingsComparatorTests: XCTestCase {
 
         system.mockExecuteResults = [
             """
-                TARGETED_DEVICE_FAMILY = 1,2
-                PROJECT_NAME = P1
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "TARGETED_DEVICE_FAMILY": "1,2",
+                        "PROJECT_NAME": "P1"
+                    }
+                }
+            ]
             """,
             """
-                TARGETED_DEVICE_FAMILY = 1
-                PROJECT_NAME = P1_NEW
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "TARGETED_DEVICE_FAMILY": "1",
+                        "PROJECT_NAME": "P1_NEW"
+                    }
+                }
+            ]
             """,
         ]
 
@@ -264,14 +352,28 @@ final class ResolvedSettingsComparatorTests: XCTestCase {
 
         system.mockExecuteResults = [
             """
-                TAPI_VERIFY_MODE = ErrorsOnly
-                PROJECT_NAME = P1
-                CUSTOM = VALUE=1
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "TAPI_VERIFY_MODE": "ErrorsOnly",
+                        "PROJECT_NAME": "P1",
+                        "CUSTOM": "VALUE=1"
+                    }
+                }
+            ]
             """,
             """
-                TAPI_VERIFY_MODE = ErrorsOnly
-                PROJECT_NAME = P1_NEW
-                CUSTOM = VALUE=2
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "TAPI_VERIFY_MODE": "ErrorsOnly",
+                        "PROJECT_NAME": "P1_NEW",
+                        "CUSTOM": "VALUE=2"
+                    }
+                }
+            ]
             """,
         ]
 
@@ -301,12 +403,26 @@ final class ResolvedSettingsComparatorTests: XCTestCase {
 
         system.mockExecuteResults = [
             """
-                PROJECT_FILE_PATH = /Projects/Folder/P1.xcodeproj
-                PROJECT_NAME = P1
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "PROJECT_FILE_PATH": "/Projects/Folder/P1.xcodeproj",
+                        "PROJECT_NAME": "P1"
+                    }
+                }
+            ]
             """,
             """
-                PROJECT_FILE_PATH = /Projects/Folder/P1_NEW.xcodeproj
-                PROJECT_NAME = P1_NEW
+            [
+                {
+                    "action" : "build",
+                    "buildSettings" : {
+                        "PROJECT_FILE_PATH": "/Projects/Folder/P1_NEW.xcodeproj",
+                        "PROJECT_NAME": "P1_NEW"
+                    }
+                }
+            ]
             """,
         ]
 
@@ -318,5 +434,33 @@ final class ResolvedSettingsComparatorTests: XCTestCase {
             .init(tag: "resolved_settings",
                   context: ["\"Target1\" target", "\"Debug\" configuration", "Values"]),
         ])
+    }
+
+    func testCompare_whenInvalidJson() throws {
+        // Given
+        let first = project(name: "P1")
+            .addBuildConfiguration(name: "Debug")
+            .addTarget(name: "Target1")
+            .projectDescriptor()
+        let second = project(name: "P1_NEW")
+            .addBuildConfiguration(name: "Debug")
+            .addTarget(name: "Target1")
+            .projectDescriptor()
+
+        system.mockExecuteResults = [
+            """
+            invalid json
+            """,
+            """
+            []
+            """,
+        ]
+
+        // When / Then
+        XCTAssertThrowsError(try subject.compare(first, second, parameters: .all)) { error in
+            XCTAssertEqual(error.localizedDescription,
+                           "Cannot extract build settings from the project, invalid json output of xcodebuild command " +
+                               "(project = /projectDirPath, target = Target1, configuration = Debug)")
+        }
     }
 }


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #63*

**Describe your changes**
Use `-json` parameter for `xcodebuild -showBuildSettings` command to simplify the output parsing.

**Testing performed**
- Ran `xcdiff -g resolved_settings` on projects with different settings, verify the diff output is correct
- Ran `xcdiff -g resolved_settings` on projects with the same settings, ensure no differences are found

