### PR TITLE
Switch to Xcode12 and MacOS 10.15 for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: swift
 os: osx
-osx_image: xcode11.5
+osx_image: xcode12
 script:
   - ./Scripts/brew.sh && make lint
   - make clean build

--- a/Scripts/Formulas/swiftformat.rb
+++ b/Scripts/Formulas/swiftformat.rb
@@ -1,0 +1,34 @@
+class Swiftformat < Formula
+  desc "Formatting tool for reformatting Swift code"
+  homepage "https://github.com/nicklockwood/SwiftFormat"
+  url "https://github.com/nicklockwood/SwiftFormat/archive/0.40.13.tar.gz"
+  sha256 "a61441673b0ef3c4c088b873fed377866a230c2ff3ba0d5e91f2a105664be05d"
+  head "https://github.com/nicklockwood/SwiftFormat.git", :shallow => false
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "216b41d26aefdd32f278d56b91a6394cb32d06295c3338ebd982ddcbc74b6d3c" => :catalina
+    sha256 "5db9699c3a6be7d2fa9713e229719fdf0fbb64254f8491860eb67bc71d8c3b01" => :mojave
+    sha256 "7011a5ed4606fe67d98e855a0515eccdaf9f1b30e582f5adbfbde1cdaac48f4e" => :high_sierra
+  end
+
+  depends_on :xcode => ["10.1", :build]
+
+  def install
+    xcodebuild "-project",
+        "SwiftFormat.xcodeproj",
+        "-scheme", "SwiftFormat (Command Line Tool)",
+        "CODE_SIGN_IDENTITY=",
+        "SYMROOT=build", "OBJROOT=build"
+    bin.install "build/Release/swiftformat"
+  end
+
+  test do
+    (testpath/"potato.swift").write <<~EOS
+      struct Potato {
+        let baked: Bool
+      }
+    EOS
+    system "#{bin}/swiftformat", "#{testpath}/potato.swift"
+  end
+end

--- a/Scripts/Formulas/swiftlint.rb
+++ b/Scripts/Formulas/swiftlint.rb
@@ -1,0 +1,30 @@
+class Swiftlint < Formula
+  desc "Tool to enforce Swift style and conventions"
+  homepage "https://github.com/realm/SwiftLint"
+  url "https://github.com/realm/SwiftLint.git",
+      :tag      => "0.35.0",
+      :revision => "8dc8421a49f2b74f79da3ef514a26249027309b9"
+  head "https://github.com/realm/SwiftLint.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "fd44022dfec1c42bd2041aebbff5dd5e6b23d9cd3b129e03c9c39cbef3280790" => :catalina
+    sha256 "1cc25d57420ea3a42f6156b733e926e91494a3b0b01caba8e7be15a0fbf107b9" => :mojave
+    sha256 "3985b4244c0fc5035fbfcddb1234b299b4390821a5f463d2d809f548067cb7bf" => :high_sierra
+  end
+
+  depends_on :xcode => ["10.0", :build]
+  depends_on :xcode => "8.0"
+
+  def install
+    system "make", "prefix_install", "PREFIX=#{prefix}", "TEMPORARY_FOLDER=#{buildpath}/SwiftLint.dst"
+  end
+
+  test do
+    (testpath/"Test.swift").write "import Foundation"
+    assert_match "Test.swift:1:1: warning: Trailing Newline Violation: Files should have a single trailing newline. (trailing_newline)",
+                 shell_output("SWIFTLINT_SWIFT_VERSION=3 SWIFTLINT_DISABLE_SOURCEKIT=1 #{bin}/swiftlint lint --no-cache").chomp
+    assert_match version.to_s,
+                 shell_output("#{bin}/swiftlint version").chomp
+  end
+end

--- a/Scripts/brew.sh
+++ b/Scripts/brew.sh
@@ -3,27 +3,26 @@
 function install_formula {
     brew list $1 2> /dev/null
     if [[ $? == 0 ]] ; then
-        brew outdated "$2" || brew reinstall "$2"
-    else
-        brew install "$2"
+        brew list "$1" && brew uninstall "$1"
     fi
+    brew install "$1.rb"
 }
 
 function main {
-    # 0.35.0
-    SWIFTLINT_FORMULA="https://raw.githubusercontent.com/Homebrew/homebrew-core/a150ab2162228b957db1871947315f2278b21252/Formula/swiftlint.rb"
-
-    # 0.40.13
-    SWIFTFORMAT_FORMULA="https://raw.githubusercontent.com/Homebrew/homebrew-core/cd3ba980c503d06fdc8daf796e2ddb795685b555/Formula/swiftformat.rb"
+    # go to formulas
+    pushd "Scripts/Formulas"
 
     # disable homebrew auto update
     export HOMEBREW_NO_AUTO_UPDATE=1
 
     # install (or reinstall) swiftlint
-    install_formula swiftlint $SWIFTLINT_FORMULA
+    install_formula swiftlint
 
     # install (or reinstall) swiftformat
-    install_formula swiftformat $SWIFTFORMAT_FORMULA
+    install_formula swiftformat
+
+    # go back
+    popd
 }
 
 main


### PR DESCRIPTION
- Updated CI image to use Xcode12
- Updated `brew.sh` script as the brew installation from URL does not work in the latest brew version. Likely @kwridan idea of using local`<formula>.rb` file works. It struggles with longer relative paths (i.e. `brew install Scripts/Formulas/swiftlint.rb` - I guess the path is treated as a tap/cask identifier), but works well if called with just filename (`brew install swiftlint.rb`).
-  It looks the new macOS image comes with a preinstalled version of SwiftLint, tweaked the script to enforce using the version from the local formula.

Test Plan:
- CI