### PR TITLE
Correct `ComparatorParameters.init`'s argument label (`configuration`=> `configurations`)

### DIFF
--- a/Documentation/Framework.md
+++ b/Documentation/Framework.md
@@ -22,7 +22,7 @@ func compare() {
                                                             mode: mode)
 
     // prepare parameters
-    let parameters = ComparatorParameters(targets: .all, configuration: .all)
+    let parameters = ComparatorParameters(targets: .all, configurations: .all)
 
     // compare and get the result
     let result = try projectComparator.compare(path1, path2, parameters: parameters)


### PR DESCRIPTION

**Describe your changes**

Correct `ComparatorParameters.init`'s argument label (`configuration` => `configurations`)

**Testing performed**

It's just a fix for the documentation. There are no changes to the code.
