### PR TITLE
Add regenerate command snapshots to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,6 @@ lint:
 	swiftformat --version
 	swiftlint --strict --quiet
 	swiftformat . --lint
+
+regenerate_command_snapshots:
+	./Scripts/generate_tests_commands_files.py

--- a/Tests/XCDiffCommandTests/CommandBasedTests.swift
+++ b/Tests/XCDiffCommandTests/CommandBasedTests.swift
@@ -32,6 +32,12 @@ final class CommandBasedTests: XCTestCase {
             let subject = CommandRunner(printer: printer)
             let exitCode = subject.run(with: command.command)
 
+            //
+            // Note: In the event this test fails, it means that the produced output from xcdiff
+            // now mismatches the snapshotes previously captured.
+            //
+            // Snapshots can be re-generated via running `make regenerate_command_snapshots`.
+            //
             XCTAssertEqual(printer.output, command.expectedOutput,
                            "'\(command)' didn't produce expected output.")
             XCTAssertEqual(exitCode, command.expectedExitCode,


### PR DESCRIPTION
- For convenience the command to regenerate command snapshots has been added to the makefile

Test Plan:

- run `make regenerate_command_snapshots`
