### PR TITLE
Allow to decrease the coverage by up to 0.5%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    patch:
+      default:
+        threshold: 5%
+    project:
+      default:
+        threshold: 0.5%


### PR DESCRIPTION
**Describe your changes**
Making all code contributions with nearly 100% coverage is not always worth the effort as such we want to introduce a little margin. We've added a custom codecov config file (`.codecov.yml`) to pass PR checks if project regresses by less than 0.5% and the coverage of the changes is within 5% threshold compare to the coverage of the main branch.
