### PR TITLE
Update version of tools used

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,2 +1,5 @@
 --exclude Fixtures
 --swiftversion 5
+
+--disable enumNamespaces
+--disable wrapMultilineStatementBraces

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: swift
 os: osx
-osx_image: xcode12.4
+osx_image: xcode12.5
 script:
   - ./Scripts/brew.sh && make lint
   - make clean build

--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,8 @@ lint:
 	swiftformat . --lint
 
 regenerate_command_snapshots:
-	./Scripts/generate_tests_commands_files.py
+	./Scripts/generate_tests_commands_files.p
+
+install_tools:
+	./Scripts/brew.sh
+

--- a/Scripts/Formulas/swiftformat.rb
+++ b/Scripts/Formulas/swiftformat.rb
@@ -1,23 +1,25 @@
 class Swiftformat < Formula
   desc "Formatting tool for reformatting Swift code"
   homepage "https://github.com/nicklockwood/SwiftFormat"
-  url "https://github.com/nicklockwood/SwiftFormat/archive/0.40.13.tar.gz"
-  sha256 "a61441673b0ef3c4c088b873fed377866a230c2ff3ba0d5e91f2a105664be05d"
-  head "https://github.com/nicklockwood/SwiftFormat.git", :shallow => false
+  url "https://github.com/nicklockwood/SwiftFormat/archive/0.48.11.tar.gz"
+  sha256 "e094d9dcfa377d327fa53316b60776b47944d93fb85ae8e1ba217a954d95eeba"
+  license "MIT"
+  head "https://github.com/nicklockwood/SwiftFormat.git"
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "216b41d26aefdd32f278d56b91a6394cb32d06295c3338ebd982ddcbc74b6d3c" => :catalina
-    sha256 "5db9699c3a6be7d2fa9713e229719fdf0fbb64254f8491860eb67bc71d8c3b01" => :mojave
-    sha256 "7011a5ed4606fe67d98e855a0515eccdaf9f1b30e582f5adbfbde1cdaac48f4e" => :high_sierra
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "e0a851cfa2ff5d04f0fc98a9e624d1411f1b5b1e55e3cbc0901f4913c02e716a"
+    sha256 cellar: :any_skip_relocation, big_sur:       "a5327283fe32b2ef2c6f264e14c966a9a60cb291415d3d05ed659c92a93c4987"
+    sha256 cellar: :any_skip_relocation, catalina:      "ba95e49ecc71bb19734698dee565e3b0ced6470729206cb434675cfa051f2755"
+    sha256 cellar: :any_skip_relocation, mojave:        "c7e00eae9d46dddf040999f0f2832d08110f093c7a403aaaaaa18d8830213967"
   end
 
-  depends_on :xcode => ["10.1", :build]
+  depends_on xcode: ["10.1", :build]
 
   def install
-    xcodebuild "-project",
-        "SwiftFormat.xcodeproj",
+    xcodebuild "-arch", Hardware::CPU.arch,
+        "-project", "SwiftFormat.xcodeproj",
         "-scheme", "SwiftFormat (Command Line Tool)",
+        "-configuration", "Release",
         "CODE_SIGN_IDENTITY=",
         "SYMROOT=build", "OBJROOT=build"
     bin.install "build/Release/swiftformat"

--- a/Scripts/Formulas/swiftlint.rb
+++ b/Scripts/Formulas/swiftlint.rb
@@ -2,29 +2,31 @@ class Swiftlint < Formula
   desc "Tool to enforce Swift style and conventions"
   homepage "https://github.com/realm/SwiftLint"
   url "https://github.com/realm/SwiftLint.git",
-      :tag      => "0.35.0",
-      :revision => "8dc8421a49f2b74f79da3ef514a26249027309b9"
+      tag:      "0.43.1",
+      revision: "180d94132758dd183124ab1e63d6aa8e10023ec2"
+  license "MIT"
   head "https://github.com/realm/SwiftLint.git"
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "fd44022dfec1c42bd2041aebbff5dd5e6b23d9cd3b129e03c9c39cbef3280790" => :catalina
-    sha256 "1cc25d57420ea3a42f6156b733e926e91494a3b0b01caba8e7be15a0fbf107b9" => :mojave
-    sha256 "3985b4244c0fc5035fbfcddb1234b299b4390821a5f463d2d809f548067cb7bf" => :high_sierra
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "e1b633e61793b924f5875e4812b49184c91fc6580bfd497ab650fe13fbbe8d8f"
+    sha256 cellar: :any_skip_relocation, big_sur:       "90faabe65db0f6bc43c3752b3b6d541e7e23cd0f368035dcef57503d74ed9581"
+    sha256 cellar: :any_skip_relocation, catalina:      "c1396dec887bf6d7986c35f38101955fb1a5c527ad4cd459174b3841dfa62239"
   end
 
-  depends_on :xcode => ["10.0", :build]
-  depends_on :xcode => "8.0"
+  depends_on xcode: ["11.4", :build]
+  depends_on xcode: "8.0"
 
   def install
-    system "make", "prefix_install", "PREFIX=#{prefix}", "TEMPORARY_FOLDER=#{buildpath}/SwiftLint.dst"
+    system "swift", "build", "--disable-sandbox", "--configuration", "release"
+    bin.install ".build/release/swiftlint"
   end
 
   test do
     (testpath/"Test.swift").write "import Foundation"
-    assert_match "Test.swift:1:1: warning: Trailing Newline Violation: Files should have a single trailing newline. (trailing_newline)",
-                 shell_output("SWIFTLINT_SWIFT_VERSION=3 SWIFTLINT_DISABLE_SOURCEKIT=1 #{bin}/swiftlint lint --no-cache").chomp
+    assert_match "Test.swift:1:1: warning: Trailing Newline Violation: " \
+                 "Files should have a single trailing newline. (trailing_newline)",
+      shell_output("SWIFTLINT_SWIFT_VERSION=3 SWIFTLINT_DISABLE_SOURCEKIT=1 #{bin}/swiftlint lint --no-cache").chomp
     assert_match version.to_s,
-                 shell_output("#{bin}/swiftlint version").chomp
+      shell_output("#{bin}/swiftlint version").chomp
   end
 end

--- a/Scripts/brew.sh
+++ b/Scripts/brew.sh
@@ -12,8 +12,8 @@ function main {
     # go to formulas
     pushd "Scripts/Formulas"
 
-    # update homebrew
-    brew update
+    # disable homebrew auto update
+    export HOMEBREW_NO_AUTO_UPDATE=1
 
     # install (or reinstall) swiftlint
     install_formula swiftlint

--- a/Scripts/brew.sh
+++ b/Scripts/brew.sh
@@ -12,8 +12,8 @@ function main {
     # go to formulas
     pushd "Scripts/Formulas"
 
-    # disable homebrew auto update
-    export HOMEBREW_NO_AUTO_UPDATE=1
+    # update homebrew
+    brew update
 
     # install (or reinstall) swiftlint
     install_formula swiftlint

--- a/Sources/XCDiffCore/Comparator/LinkedDependenciesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/LinkedDependenciesComparator.swift
@@ -73,7 +73,7 @@ final class LinkedDependenciesComparator: Comparator {
             .map { (firstDependencyDescriptorMap[$0]!, secondDependencyDescriptorMap[$0]!) }
             .sorted { left, right in
                 if let keyLeft = left.0.name ?? left.0.path,
-                    let keyRight = right.0.name ?? right.0.path {
+                   let keyRight = right.0.name ?? right.0.path {
                     return keyLeft < keyRight
                 }
                 return false
@@ -115,6 +115,6 @@ final class LinkedDependenciesComparator: Comparator {
             if let key = dependencyKey(dependency: $0) { return (key, $0) }
             return nil
         },
-                          uniquingKeysWith: { first, _ in first })
+        uniquingKeysWith: { first, _ in first })
     }
 }

--- a/Sources/XCDiffCore/Comparator/SettingsComparator.swift
+++ b/Sources/XCDiffCore/Comparator/SettingsComparator.swift
@@ -106,7 +106,7 @@ final class SettingsComparator: Comparator {
         let firstConfigurationOptional = first?.configuration(name: configurationName)
         let secondConfigurationOptional = second?.configuration(name: configurationName)
         guard let firstConfiguration = firstConfigurationOptional,
-            let secondConfiguration = secondConfigurationOptional else {
+              let secondConfiguration = secondConfigurationOptional else {
             if firstConfigurationOptional == nil, secondConfigurationOptional == nil {
                 return [CompareResult(tag: tag, context: context)]
             }

--- a/Sources/XCDiffCore/Comparator/SwiftPackagesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/SwiftPackagesComparator.swift
@@ -40,7 +40,7 @@ final class SwiftPackagesComparator: Comparator {
 
         let differencesValues: [CompareResult.DifferentValues] = differences.compactMap {
             guard let first = firstDictionary[$0.identifier],
-                let second = secondDictionary[$0.identifier] else {
+                  let second = secondDictionary[$0.identifier] else {
                 return nil
             }
 

--- a/Sources/XCDiffCore/Library/TargetsHelper.swift
+++ b/Sources/XCDiffCore/Library/TargetsHelper.swift
@@ -135,7 +135,7 @@ final class TargetsHelper {
 
     func linkedDependencies(from target: PBXTarget) throws -> [LinkedDependencyDescriptor] {
         guard let linkedDependencies = target.buildPhases.compactMap({ $0 as? PBXFrameworksBuildPhase }).first,
-            let dependencyFiles = linkedDependencies.files else {
+              let dependencyFiles = linkedDependencies.files else {
             return []
         }
         return dependencyFiles.compactMap {
@@ -166,7 +166,7 @@ final class TargetsHelper {
 
     func targetAttributes(pbxproj: PBXProj, target: PBXTarget) throws -> [String: String] {
         guard let rootProject = try pbxproj.rootProject(),
-            let attributes = rootProject.targetAttributes[target] else {
+              let attributes = rootProject.targetAttributes[target] else {
             return [:]
         }
 

--- a/Sources/XCDiffCore/Library/URL+Extensions.swift
+++ b/Sources/XCDiffCore/Library/URL+Extensions.swift
@@ -29,8 +29,8 @@ extension URL {
 
         var index = 0
         while index < destinationComp.count,
-            index < baseComp.count,
-            destinationComp[index] == baseComp[index] {
+              index < baseComp.count,
+              destinationComp[index] == baseComp[index] {
             index += 1
         }
 


### PR DESCRIPTION
Resolves: #89

**Describe your changes**

- Travis image updated to Xcode12.5 _(uses a newer version of homebrew)_
- SwiftFormat has been bumped to 0.48.11
- SwiftLint has been bumped to 0.43.1
- Code has been re-formated for compatibility with the latest SwiftFormat
  - Note a few rules have been disabled to minimize changes (those can be revisted separately if needed)
- Added the brew installation script to the Makefile for convenience - it can be run via `make install_tools`

**Test Plan**

- Run `make install_tools`
- Verify the installation of tools works
- Run `make lint`
- Verify the checks pass
