### PR TITLE
Add GitHub workflow for CI

### DIFF
--- a/.github/workflows/xcdiff.yaml
+++ b/.github/workflows/xcdiff.yaml
@@ -1,0 +1,31 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  DEVELOPER_DIR: "/Applications/Xcode_12.5.1.app/Contents/Developer"
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: macOS-11
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: ./Scripts/brew.sh
+    - name: lint
+      run: make lint
+
+  build:
+    name: Build & Test
+    runs-on: macOS-11
+    steps:
+    - uses: actions/checkout@v2
+    - name: build
+      run: make clean build
+    - name: test
+      run: make test_ci

--- a/.github/workflows/xcdiff.yaml
+++ b/.github/workflows/xcdiff.yaml
@@ -9,6 +9,11 @@ on:
 env:
   DEVELOPER_DIR: "/Applications/Xcode_12.5.1.app/Contents/Developer"
 
+# Limit GITHUB_TOKEN permissions to read-only for repo contents
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
@@ -25,7 +30,13 @@ jobs:
     runs-on: macOS-11
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
     - name: build
-      run: make clean build
+      run: make build
     - name: test
       run: make test_ci


### PR DESCRIPTION
**Describe your changes**

- A new `xcdiff` GitHub workflow is being added for CI
- Currently configures 2 separate jobs 
  - Linting
  - Build & Test
-  The build and test were grouped together as running them on the same node allows re-using some of the cached build artefacts

**Additional context**

We'd like to migrate off of Travis to GitHub Actions, this PR introduces the GitHub workflow, once verified we can remove the `.travis.yml` file.



