### PR TITLE
Update dependencies to build with Xcode 13.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "AEXML",
-        "repositoryURL": "https://github.com/tadija/AEXML",
+        "repositoryURL": "https://github.com/tadija/AEXML.git",
         "state": {
           "branch": null,
-          "revision": "8623e73b193386909566a9ca20203e33a09af142",
-          "version": "4.5.0"
+          "revision": "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
+          "version": "4.6.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit",
         "state": {
           "branch": null,
-          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
-          "version": "1.0.0"
+          "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+          "version": "1.0.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
-          "version": "0.9.0"
+          "revision": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+          "version": "0.10.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "81e2cda46447b4d78c18e03b0d284d76950f7c2b",
-          "version": "0.1.5"
+          "revision": "f9bbd6b80d67408021576adf6247e17c2e957d92",
+          "version": "0.2.4"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
           "branch": null,
-          "revision": "0b18c3e7a10c241323397a80cb445051f4494971",
-          "version": "8.0.0"
+          "revision": "64c4b956c1095dbba7a07107005342a25f1c5d6b",
+          "version": "8.5.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -23,9 +23,9 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMajor(from: "0.1.0")),
-        .package(url: "https://github.com/kylef/PathKit", .upToNextMinor(from: "1.0.0")),
-        .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMajor(from: "8.0.0")),
+        .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMajor(from: "0.2.4")),
+        .package(url: "https://github.com/kylef/PathKit", .upToNextMinor(from: "1.0.1")),
+        .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMajor(from: "8.5.0")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
**Describe your changes**
Updated project dependencies such as xcodeproj, pathkit, and swift-tools-support-core, so the project can be built with Xcode 13.1.

**Testing performed**
- Ensure all CI checks pass
- Check out the project, verify it builts with Xcode 13.1

**Additional context**
- Building with Xcode 13.1 yields multiple warnings `warning: 'ArgumentParser' is deprecated: use swift-argument-parser instead`. It will require a follow-up (https://github.com/bloomberg/xcdiff/issues/94).
- We will also need to update the CI configuration to build with Xcode 13.1 (https://github.com/bloomberg/xcdiff/issues/96).
