### PR TITLE
Remove .travis.yml config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: swift
-os: osx
-osx_image: xcode12.5
-script:
-  - ./Scripts/brew.sh && make lint
-  - make clean build
-  - make clean test_ci

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
    <img src="Documentation/Resources/xcdiff.png" alt="xcdiff logo" />
 </p>
 
-[![Build Status](https://travis-ci.com/bloomberg/xcdiff.svg?branch=master)](https://travis-ci.com/bloomberg/xcdiff)
-[![Coverage Status](https://codecov.io/gh/bloomberg/xcdiff/branch/master/graph/badge.svg)](https://codecov.io/gh/bloomberg/xcdiff)
+[![Build Status](https://github.com/bloomberg/xcdiff/actions/workflows/xcdiff.yaml/badge.svg)](https://github.com/bloomberg/xcdiff/actions/workflows/xcdiff.yaml)
+[![Coverage Status](https://codecov.io/gh/bloomberg/xcdiff/branch/main/graph/badge.svg)](https://codecov.io/gh/bloomberg/xcdiff)
 
 *xcdiff* is an extensible tool that **finds differences between two .xcodeproj project files**. It can be thought of as git diff for .xcodeproj files, which can be used directly from the command line as well as a library supporting your own set of tools.
 


### PR DESCRIPTION
**Describe your changes**
Remove Travis CI configuration file. The repository is now using Github Actions (https://github.com/bloomberg/xcdiff/pull/93).

**Testing performed**
- Verify all CI checks pass
- Ensure both build and coverage status badges are rendered correctly and the links are valid

