### PR TITLE
Update GitHub Actions workflow to use Xcode 13.3

### DIFF
--- a/.github/workflows/xcdiff.yaml
+++ b/.github/workflows/xcdiff.yaml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  DEVELOPER_DIR: "/Applications/Xcode_12.5.1.app/Contents/Developer"
+  DEVELOPER_DIR: "/Applications/Xcode_13.3.app/Contents/Developer"
 
 # Limit GITHUB_TOKEN permissions to read-only for repo contents
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
@@ -17,7 +17,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: macOS-11
+    runs-on: macOS-12
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -27,7 +27,7 @@ jobs:
 
   build:
     name: Build & Test
-    runs-on: macOS-11
+    runs-on: macOS-12
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #103*

**Describe your changes**
Update GitHub Actions workflow to use Xcode 13.3 and macOS 12

**Testing performed**
The project builds and test succeed in given Xcode version.

Signed-off-by: Dmytro Anokhin <5136301+dmytro-anokhin@users.noreply.github.com>
