### PR TITLE
build arm64 and x86_64 binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GIT_SHORT_HASH = $(shell git rev-parse --short HEAD)
 TOOL_NAME = xcdiff
 PREFIX = /usr/local
 INSTALL_PATH = $(PREFIX)/bin/
-BUILD_PATH = .build/release/$(TOOL_NAME)
+BUILD_PATH = .build/apple/Products/Release/$(TOOL_NAME)
 
 clean:
 	xcrun swift package clean
@@ -17,7 +17,7 @@ install: clean build
 	cp -f $(BUILD_PATH) $(INSTALL_PATH)
 
 build:
-	xcrun swift build --disable-sandbox -c release
+	xcrun swift build --disable-sandbox -c release --arch arm64 --arch x86_64
 
 test:
 	xcrun swift test --enable-code-coverage


### PR DESCRIPTION
Signed-off-by: Roland Heusser <skofgar@users.noreply.github.com>

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

It looks like xcdiff is built as `arm64` or `x86_64`, depending on what host it is built on. In order to support both Intel and Apple Silicon Macs a universal binary should be built instead.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

```
% make build                               
xcrun swift build --disable-sandbox -c release --arch arm64 --arch x86_64
...
% file .build/apple/Products/Release/xcdiff
.build/apple/Products/Release/xcdiff: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64Mach-O 64-bit executable x86_64] [arm64]
.build/apple/Products/Release/xcdiff (for architecture x86_64):	Mach-O 64-bit executable x86_64
.build/apple/Products/Release/xcdiff (for architecture arm64):	Mach-O 64-bit executable arm64
```

Furthermore the resulting `xcdiff` binary was tested on Apple Silicon and Intel Macs.

**Additional context**
Add any other context about your contribution here.

Similar solutions are used in other projects like [XcodeGen's Makefile](https://github.com/yonaskolb/XcodeGen/blob/master/Makefile#L12)

Please delete #108 