### PR TITLE
Fix brew install warning

### DIFF
--- a/Scripts/brew.sh
+++ b/Scripts/brew.sh
@@ -5,7 +5,7 @@ function install_formula {
     if [[ $? == 0 ]] ; then
         brew list "$1" && brew uninstall "$1"
     fi
-    brew install "$1.rb"
+    brew install --formula "$1.rb"
 }
 
 function main {


### PR DESCRIPTION
**Describe your changes**
An error was printed when called `brew install swiftlint.rb`. It turned out brew has now `install --formula` parameter which allows to install from local formula file.

```bash
...
Error: Failed to load cask: swiftlint.rb
Cask 'swiftlint' is unreadable: wrong constant name #<Class:0x000000013f213780>
Warning: Treating swiftlint.rb as a formula.
...
```

**Testing performed**
- Ensure all CI checks pass
- Inspect CI logs, ensure no error or warning is reported

