### PR TITLE
Fix brew install

### DIFF
--- a/Scripts/brew.sh
+++ b/Scripts/brew.sh
@@ -5,7 +5,7 @@ function install_formula {
     if [[ $? == 0 ]] ; then
         brew list "$1" && brew uninstall "$1"
     fi
-    brew install --formula "$1.rb"
+    brew install --formula "$1.rb" --overwrite
 }
 
 function main {


### PR DESCRIPTION
**Describe your changes**
The installation failed to replace the old version of swiftlint, added `--override` flag to force-install.

```sh
2022-12-30T09:14:46.9499920Z [34m==>[0m [1mDownloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:73a9664d8a62c7b5d506a70bf100e0289795df04ece6df12f0b77651e497d42b?se=2022-12-30T09%3A20%3A00Z&sig=eOOVCk%2BBABlFuIbX1nOuFTsAzSNk24IGIUg6DiEj9Q4%3D&sp=r&spr=https&sr=b&sv=2019-12-12[0m
2022-12-30T09:14:47.3381330Z [33mWarning:[0m swiftlint 0.50.3 is available and more recent than version 0.49.1.
2022-12-30T09:14:47.3405350Z [34m==>[0m [1mPouring swiftlint--0.49.1.monterey.bottle.tar.gz[0m
2022-12-30T09:14:47.8176640Z [31mError:[0m The `brew link` step did not complete successfully
2022-12-30T09:14:47.8177060Z The formula built, but is not symlinked into /usr/local
2022-12-30T09:14:47.8178750Z Could not symlink bin/swiftlint
2022-12-30T09:14:47.8179080Z Target /usr/local/bin/swiftlint
2022-12-30T09:14:47.8179360Z already exists. You may want to remove it:
2022-12-30T09:14:47.8179810Z   rm '/usr/local/bin/swiftlint'
2022-12-30T09:14:47.8179980Z 
2022-12-30T09:14:47.8180140Z To force the link and overwrite all conflicting files:
2022-12-30T09:14:47.8180550Z   brew link --overwrite swiftlint
2022-12-30T09:14:47.8180980Z 
2022-12-30T09:14:47.8181110Z To list all files that would be deleted:
2022-12-30T09:14:47.8181570Z   brew link --overwrite --dry-run swiftlint
2022-12-30T09:14:47.8181750Z 
2022-12-30T09:14:47.8181890Z Possible conflicting files are:
2022-12-30T09:14:47.8182200Z /usr/local/bin/swiftlint
```

**Testing performed**
- Ensure all CI checks pass