### PR TITLE
Shorthand Optional Binding

### DIFF
--- a/Sources/XCDiffCommand/CommandRunner.swift
+++ b/Sources/XCDiffCommand/CommandRunner.swift
@@ -65,7 +65,7 @@ public final class CommandRunner {
     }
 
     private func complete(commandType: ParsableCommand.Type, withError error: Error? = nil) -> Int32 {
-        guard let error = error else {
+        guard let error else {
             return ExitCode.success.rawValue
         }
 
@@ -141,7 +141,7 @@ public final class CommandRunner {
     }
 
     private func getPaths(_ path1Arg: String?, _ path2Arg: String?) throws -> (Path, Path) {
-        if let path1Arg = path1Arg, let path2Arg = path2Arg {
+        if let path1Arg, let path2Arg {
             let path1 = Path(path1Arg)
             let path2 = Path(path2Arg)
             guard path1.exists else {

--- a/Sources/XCDiffCore/Comparator/CopyFilesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/CopyFilesComparator.swift
@@ -61,12 +61,12 @@ final class CopyFilesComparator: Comparator {
     private func compare(_ first: CopyFilesBuildPhaseDescriptor?,
                          _ second: CopyFilesBuildPhaseDescriptor?,
                          context: [String]) throws -> CompareResult {
-        guard let first = first else {
+        guard let first else {
             return result(context: context,
                           description: "The build phase does not exist in the first project",
                           onlyInSecond: ["Duplicated build phase name"])
         }
-        guard let second = second else {
+        guard let second else {
             return result(context: context,
                           description: "The build phase does not exist in the second project",
                           onlyInFirst: ["Duplicated build phase name"])

--- a/Sources/XCDiffCore/Comparator/DependenciesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/DependenciesComparator.swift
@@ -86,7 +86,7 @@ private struct DependencyDescriptor {
         }
 
         private func string(from proxyType: PBXContainerItemProxy.ProxyType?) -> String? {
-            guard let proxyType = proxyType else {
+            guard let proxyType else {
                 return nil
             }
             switch proxyType {
@@ -123,15 +123,15 @@ private struct DependencyDescriptor {
 
         // name
         if case let .target(target) = context {
-            if let name = name, name != target {
+            if let name, name != target {
                 result.append("name=\(name)")
             }
-        } else if let name = name {
+        } else if let name {
             result.append("name=\(name)")
         }
 
         // product name
-        if let productName = productName {
+        if let productName {
             result.append("product_name=\(productName.description)")
         }
 

--- a/Sources/XCDiffCore/Comparator/ResolvedSettingsComparator.swift
+++ b/Sources/XCDiffCore/Comparator/ResolvedSettingsComparator.swift
@@ -87,11 +87,11 @@ final class ResolvedSettingsComparator: Comparator {
             path,
         ]
 
-        if let target = target {
+        if let target {
             arguments.append(contentsOf: ["-target", target])
         }
 
-        if let config = config {
+        if let config {
             arguments.append(contentsOf: ["-config", config])
         }
 

--- a/Sources/XCDiffCore/Comparator/RunScriptComparator.swift
+++ b/Sources/XCDiffCore/Comparator/RunScriptComparator.swift
@@ -60,12 +60,12 @@ final class RunScriptComparator: Comparator {
     private func compare(_ first: RunScriptBuildPhaseDescriptor?,
                          _ second: RunScriptBuildPhaseDescriptor?,
                          context: [String]) throws -> CompareResult {
-        guard let first = first else {
+        guard let first else {
             return result(context: context,
                           description: "The build phase does not exist in the first project",
                           onlyInSecond: ["Duplicated build phase name"])
         }
-        guard let second = second else {
+        guard let second else {
             return result(context: context,
                           description: "The build phase does not exist in the second project",
                           onlyInFirst: ["Duplicated build phase name"])

--- a/Sources/XCDiffCore/Library/Descriptors/SwiftPackageDescriptor.swift
+++ b/Sources/XCDiffCore/Library/Descriptors/SwiftPackageDescriptor.swift
@@ -30,7 +30,7 @@ struct SwiftPackageDescriptor: Hashable, CustomStringConvertible, Comparable {
     }
 
     func difference(from other: SwiftPackageDescriptor?) -> String? {
-        guard let other = other else {
+        guard let other else {
             return description
         }
         guard other != self else {

--- a/Sources/XCDiffCore/Library/SettingValueComparator.swift
+++ b/Sources/XCDiffCore/Library/SettingValueComparator.swift
@@ -25,7 +25,7 @@ class SettingValueComparator: ValueComparator {
     // MARK: - Lifecycle
 
     init(firstProjectName: String?, secondProjectName: String?) {
-        guard let firstProjectName = firstProjectName, let secondProjectName = secondProjectName else {
+        guard let firstProjectName, let secondProjectName else {
             projectNameDifference = nil
             return
         }
@@ -51,7 +51,7 @@ class SettingValueComparator: ValueComparator {
         guard lha != rha else {
             return true
         }
-        guard let projectNameDifference = projectNameDifference else {
+        guard let projectNameDifference else {
             return lha == rha
         }
         let settingValuesDifference = stringDiff.diff(lha, rha)

--- a/Sources/XCDiffCore/Library/SettingsHelper.swift
+++ b/Sources/XCDiffCore/Library/SettingsHelper.swift
@@ -62,7 +62,7 @@ class SettingsHelper {
 
     private func stringFromBuildSetting(_ buildSetting: Any?) throws -> String {
         // try to unwrap
-        guard let buildSetting = buildSetting else {
+        guard let buildSetting else {
             return "nil"
         }
 

--- a/Sources/XCDiffCore/ResultRenderer/Renderer/HTMLRenderer.swift
+++ b/Sources/XCDiffCore/ResultRenderer/Renderer/HTMLRenderer.swift
@@ -189,7 +189,7 @@ final class HTMLRenderer: Renderer {
 
     private func tag(_ name: String, _ cssClass: CSSClass? = nil, _ content: () -> Void) {
         let cssClassString: String
-        if let cssClass = cssClass {
+        if let cssClass {
             cssClassString = " class=\"\(cssClass.rawValue)\""
         } else {
             cssClassString = ""

--- a/Tests/XCDiffCoreTests/Helpers/PBXBuildFileBuilder.swift
+++ b/Tests/XCDiffCoreTests/Helpers/PBXBuildFileBuilder.swift
@@ -74,7 +74,7 @@ final class PBXBuildFileBuilder {
         buildFile.platformFilter = platformFilter
         var objects: [PBXObject?] = [buildFile, fileReference]
 
-        if let packageProduct = packageProduct {
+        if let packageProduct {
             let packageReference = packageProduct.package.map {
                 XCRemoteSwiftPackageReference(
                     repositoryURL: $0.url,


### PR DESCRIPTION
Issue number of the reported bug or feature request: https://github.com/bloomberg/xcdiff/issues/124

### Describe your changes: 
- shorthand optional binding functionality arrived in `Swift 5.7`.
- making use of this shorthand will increase the readability of the codebase.
- this PR replaces the current uses of the long form. 

**Example:** 
```
let foo: FooType? = ...

if let foo = foo {
    ...
}
```

Can now be shortened to:
```
let foo: FooType? = ...

if let foo {
    ...
}
```

This also works for `guard let`, `if var`, etc. 

### Testing performed:
Ran the tests provided using `swift test`.