### PR TITLE
Add information how to install via homebrew

### DIFF
--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -23,7 +23,11 @@ export PATH="$PATH:$(swift build -c release --show-bin-path)"
 
 ### Homebrew
 
-*TODO*
+To install xcdiff using [Homebrew](https://brew.sh):
+
+```sh
+brew install xcdiff
+```
 
 ### Mint
 


### PR DESCRIPTION
*Issue number of the reported bug or feature request: https://github.com/bloomberg/xcdiff/issues/3*

Updated the documentation with short instruction how to install xcdiff via Homebrew.
