### PR TITLE
Bump Xcode version to 14.3.1

### DIFF
--- a/.github/workflows/xcdiff.yaml
+++ b/.github/workflows/xcdiff.yaml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  DEVELOPER_DIR: "/Applications/Xcode_14.2.app/Contents/Developer"
+  DEVELOPER_DIR: "/Applications/Xcode_14.3.1.app/Contents/Developer"
 
 # Limit GITHUB_TOKEN permissions to read-only for repo contents
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
@@ -17,7 +17,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: macOS-12
+    runs-on: macOS-13
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -27,7 +27,7 @@ jobs:
 
   build:
     name: Build & Test
-    runs-on: macOS-12
+    runs-on: macOS-13
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "xcdiff",
     platforms: [
-        .macOS(.v10_13),
+        .macOS(.v10_15),
     ],
     products: [
         .executable(


### PR DESCRIPTION
**Describe your changes**

- Bumped github workflow to build with macOS 13 images + Xcode 14.3.1
- Updated minimum OS to be 10.15 (as that is the minimum by some of the newer versions of the dependencies - e.g. SwiftToolsSupport)

**Testing performed**

- Verify CI passes
