### PR TITLE
Update release documentation

### DIFF
--- a/Documentation/Release.md
+++ b/Documentation/Release.md
@@ -6,8 +6,10 @@
 4. Once merged, [draft a new release](https://github.com/bloomberg/xcdiff/releases/new)
 5. Tag the release with the appropriate version
 6. Use the version number as the release title
-7. Populate the description with the recent changes since the last release. For convenience the following command can be used to generate a changelog summary:
+7. Populate the description with the recent changes since the last release. For convenience the GitHub built-in **Generate release notes** feature can be used, alternatively the following command can be used to generate a changelog summary:
 
 ```bash
 git log main...$(git describe --tags `git rev-list --tags --max-count=1`) --pretty=format:'- %s'
 ```
+8. Publish the release
+9. Update homebrew formula via locally running `make update_homebrew` _(This publishes a PR to the homebrew core repo)_

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ update_version:
 update_hash:
 	sed -i '' 's/#GIT_SHORT_HASH#/$(GIT_SHORT_HASH)/' Sources/XCDiffCommand/Constants.swift
 
+update_homebrew:
+	brew bump-formula-pr xcdiff --version="${VERSION}"
+
 format:
 	swiftformat .
 


### PR DESCRIPTION
**Describe your changes**

- Added notes on releases notes generation whic can now be done in the GitHub UI
- Update makefile to include a step to initiate homebrew formula updates via `brew bump-formula-pr xcdiff --version=...`

**References**

- https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#creating-automatically-generated-release-notes-for-a-new-release
- https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request#submit-a-new-version-of-an-existing-formula

