### PR TITLE
Add diff helper

### DIFF
--- a/Sources/XCDiffCore/Comparator/SwiftPackagesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/SwiftPackagesComparator.swift
@@ -28,35 +28,21 @@ final class SwiftPackagesComparator: Comparator {
         let firstPackages = try targetsHelper.swiftPackages(in: first)
         let secondPackages = try targetsHelper.swiftPackages(in: second)
 
-        let firstDictionary = Dictionary(firstPackages.map { ($0.identifier, $0) }, uniquingKeysWith: { $1 })
-        let secondDictionary = Dictionary(secondPackages.map { ($0.identifier, $0) }, uniquingKeysWith: { $1 })
-
-        let onlyInFirst = firstPackages.filter { secondDictionary[$0.identifier] == nil }
-        let onlyInSecond = secondPackages.filter { firstDictionary[$0.identifier] == nil }
-        let common = firstPackages.filter { secondDictionary[$0.identifier] != nil }
-        let differences = common.filter {
-            firstDictionary[$0.identifier] != secondDictionary[$0.identifier]
-        }
-
-        let differencesValues: [CompareResult.DifferentValues] = differences.compactMap {
-            guard let first = firstDictionary[$0.identifier],
-                  let second = secondDictionary[$0.identifier] else {
-                return nil
-            }
-
-            return CompareResult.DifferentValues(
-                context: "\($0.name) (\($0.url))",
-                first: first.difference(from: second),
-                second: second.difference(from: first)
-            )
-        }
-
         return [
-            CompareResult(
-                tag: tag,
-                onlyInFirst: onlyInFirst.map(\.description),
-                onlyInSecond: onlyInSecond.map(\.description),
-                differentValues: differencesValues
+            result(
+                first: firstPackages,
+                second: secondPackages,
+                diffCommonValues: { commonPairs in
+                    commonPairs.filter {
+                        $0 != $1
+                    }.map { first, second in
+                        CompareResult.DifferentValues(
+                            context: "\(first.name) (\(first.url))",
+                            first: first.difference(from: second),
+                            second: second.difference(from: first)
+                        )
+                    }
+                }
             ),
         ]
     }

--- a/Sources/XCDiffCore/Library/Descriptors/SwiftPackageDescriptor.swift
+++ b/Sources/XCDiffCore/Library/Descriptors/SwiftPackageDescriptor.swift
@@ -54,3 +54,13 @@ struct SwiftPackageDescriptor: Hashable, CustomStringConvertible, Comparable {
         return lhs.description < rhs.description
     }
 }
+
+extension SwiftPackageDescriptor: DiffComparable {
+    var diffKey: String {
+        identifier
+    }
+
+    var diffDescription: String {
+        description
+    }
+}

--- a/Sources/XCDiffCore/Library/TargetsHelper.swift
+++ b/Sources/XCDiffCore/Library/TargetsHelper.swift
@@ -20,17 +20,33 @@ import XcodeProj
 
 typealias TargetPair = (first: PBXTarget, second: PBXTarget)
 
-struct SourceDescriptor: Hashable {
+struct SourceDescriptor: Hashable, DiffComparable {
+    var diffKey: String {
+        path
+    }
+
     let path: String
     let flags: String?
 }
 
-struct HeaderDescriptor: Hashable {
+struct HeaderDescriptor: Hashable, DiffComparable {
+    var diffKey: String {
+        path
+    }
+
     let path: String
     let attributes: String?
 }
 
-struct LinkedDependencyDescriptor: Hashable {
+struct LinkedDependencyDescriptor: Hashable, DiffComparable {
+    var diffKey: String {
+        key ?? ""
+    }
+
+    var key: String? {
+        name ?? path
+    }
+
     let name: String?
     let path: String?
     let package: SwiftPackageDescriptor?


### PR DESCRIPTION
**Describe your changes**

- A new diff helper has been added for common comparator operations of diffing common elements
- The helper introduces a new `DiffComparable` type which descriptors can conform to
- Where possible comparators and descriptors were migrated to leverage it

**Testing performed**

- Verify all unit and integration tests continue to pass (i.e. no diff in output format)

**Additional context**

While working on https://github.com/bloomberg/xcdiff/issues/130 I noticed there was a small tidy up needed that wasn't directly related to platform filters but would aid its development so was pulled out as a separate change.
