### PR TITLE
Bump swift-argument-parser to 1.5.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "fddd1c00396eed152c45a46bea9f47b98e59301d",
-          "version": "1.2.0"
+          "revision": "41982a3656a71c768319979febd796c6fd111d5c",
+          "version": "1.5.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.3.0"),
         .package(url: "https://github.com/kylef/PathKit", from: "1.0.0"),
         .package(url: "https://github.com/tuist/xcodeproj.git", from: "8.15.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
Updated swift argument parser to the latest version.

Test Plan:
- Ensure all CI checks pass
