### PR TITLE
Bump XcodeProj to 8.25.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
           "branch": null,
-          "revision": "3797181813ee963fe305d939232bc576d23ddbb0",
-          "version": "8.15.0"
+          "revision": "d3df4265b8383dd56dae4b01f817d30c22e7612c",
+          "version": "8.25.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.3.0"),
         .package(url: "https://github.com/kylef/PathKit", from: "1.0.0"),
-        .package(url: "https://github.com/tuist/xcodeproj.git", from: "8.15.0"),
+        .package(url: "https://github.com/tuist/xcodeproj.git", from: "8.25.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
     ],
     targets: [

--- a/Tests/XCDiffCoreTests/Helpers/PBXProjBuilder.swift
+++ b/Tests/XCDiffCoreTests/Helpers/PBXProjBuilder.swift
@@ -127,7 +127,7 @@ final class PBXProjBuilder {
     ) -> PBXProjBuilder {
         let package = XCRemoteSwiftPackageReference(repositoryURL: url, versionRequirement: version)
         pbxproj.add(object: package)
-        pbxproj.rootObject?.packages.append(package)
+        pbxproj.rootObject?.remotePackages.append(package)
         return self
     }
 
@@ -224,6 +224,8 @@ final class PBXProjBuilder {
         let project = PBXProject(name: name,
                                  buildConfigurationList: configurationList,
                                  compatibilityVersion: Xcode.Default.compatibilityVersion,
+                                 preferredProjectObjectVersion: nil,
+                                 minimizedProjectReferenceProxies: nil,
                                  mainGroup: mainGroup,
                                  projectDirPath: projectDirPath)
         let objects = configurationListObjects + [mainGroup, project]


### PR DESCRIPTION
**Describe your changes**
Bump XcodeProj version to latest (8.25.0)

**Testing performed**
Comparing a project that is using the new buildable folders with PBXFileSystemSynchronizedBuildFileExceptionSet now without XcodeProj failing with a generic error.

**Additional context**
`XCLocalSwiftPackageReference` and `PBXFileSystemSynchronizedBuildFileExceptionSet` were unsupported. New XcodeProj version supports these elements.
