### PR TITLE
Switch to Xcode 16.2

### DIFF
--- a/.github/workflows/xcdiff.yaml
+++ b/.github/workflows/xcdiff.yaml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  DEVELOPER_DIR: "/Applications/Xcode_16.0.app/Contents/Developer"
+  DEVELOPER_DIR: "/Applications/Xcode_16.2.app/Contents/Developer"
 
 # Limit GITHUB_TOKEN permissions to read-only for repo contents
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication


### PR DESCRIPTION
Xcode 16.0 is no longer available in macos-14 image
(https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md).

Test Plan:
- Ensure all CI checks pass