### PR TITLE
Update for XcodeProj with strongly typed settings

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -59,9 +59,9 @@
         "package": "XcodeProj",
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
-          "branch": null,
-          "revision": "6f90427e172da66336739801c84b9cef3e17367b",
-          "version": "8.26.6"
+          "branch": "waltflanagan/StrongTypes",
+          "revision": "bf96639f81663c8c032a0296e75c911041c95220",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.3.0"),
         .package(url: "https://github.com/kylef/PathKit", from: "1.0.0"),
-        .package(url: "https://github.com/tuist/xcodeproj.git", from: "8.26.6"),
+        .package(url: "https://github.com/tuist/xcodeproj.git", branch: "waltflanagan/StrongTypes"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
     ],
     targets: [

--- a/Sources/XCDiffCore/Comparator/CopyFilesComparator.swift
+++ b/Sources/XCDiffCore/Comparator/CopyFilesComparator.swift
@@ -141,7 +141,7 @@ final class CopyFilesComparator: Comparator {
                 ) ?? buildFile.file?.path else {
                     return nil
                 }
-                let attributes = buildFile.settings?["ATTRIBUTES"] as? [String] ?? []
+                let attributes = buildFile.settings?["ATTRIBUTES"]?.arrayValue ?? []
 
                 return BuildFileDescriptor(
                     name: path,

--- a/Sources/XCDiffCore/Library/PBX+Extensions.swift
+++ b/Sources/XCDiffCore/Library/PBX+Extensions.swift
@@ -61,3 +61,34 @@ extension XCRemoteSwiftPackageReference.VersionRequirement: CustomStringConverti
         }
     }
 }
+
+extension BuildSetting {
+    var stringValue: String {
+        switch self {
+        case let .string(value):
+            value
+        case let .array(value):
+            value.joined(separator: ", ")
+        }
+    }
+}
+
+extension BuildFileSetting {
+    var stringValue: String {
+        switch self {
+        case let .string(value):
+            value
+        case let .array(value):
+            value.joined(separator: ", ")
+        }
+    }
+
+    var arrayValue: [String] {
+        switch self {
+        case let .string(value):
+            [value]
+        case let .array(value):
+            value
+        }
+    }
+}

--- a/Sources/XCDiffCore/Library/TargetsHelper.swift
+++ b/Sources/XCDiffCore/Library/TargetsHelper.swift
@@ -318,30 +318,11 @@ final class TargetsHelper {
 
 private extension PBXBuildFile {
     func compilerFlags() -> String? {
-        guard let flags = settings?["COMPILER_FLAGS"] else {
-            return nil
-        }
-        if let flagsString = flags as? String {
-            return flagsString
-        }
-        if let flagsArray = flags as? [String] {
-            return flagsArray.joined(separator: ", ")
-        }
-
-        return nil
+        settings?["COMPILER_FLAGS"]?.stringValue
     }
 
     func attributes() -> String? {
-        guard let anyAttributes = settings?["ATTRIBUTES"] else {
-            return nil
-        }
-        if let attributes = anyAttributes as? [String] {
-            return attributes.joined(separator: ", ")
-        }
-        if let attributes = anyAttributes as? String {
-            return attributes
-        }
-        return String(describing: anyAttributes)
+        settings?["ATTRIBUTES"]?.stringValue
     }
 }
 

--- a/Tests/XCDiffCoreTests/Helpers/PBXBuildConfigurationBuilder.swift
+++ b/Tests/XCDiffCoreTests/Helpers/PBXBuildConfigurationBuilder.swift
@@ -19,7 +19,7 @@ import XcodeProj
 
 final class PBXBuildConfigurationBuilder {
     private let name: String
-    private var buildSettings: [String: Any] = [:]
+    private var buildSettings: [String: BuildSetting] = [:]
     private var baseConfiguration: PBXFileReference?
 
     init(name: String) {
@@ -27,7 +27,7 @@ final class PBXBuildConfigurationBuilder {
     }
 
     @discardableResult
-    func setValue(_ value: Any, forKey key: String) -> PBXBuildConfigurationBuilder {
+    func setValue(_ value: BuildSetting, forKey key: String) -> PBXBuildConfigurationBuilder {
         buildSettings[key] = value
         return self
     }

--- a/Tests/XCDiffCoreTests/Helpers/PBXBuildFileBuilder.swift
+++ b/Tests/XCDiffCoreTests/Helpers/PBXBuildFileBuilder.swift
@@ -22,7 +22,7 @@ final class PBXBuildFileBuilder {
     private var name: String?
     private var platformFilter: String?
     private var platformFilters: [String]?
-    private var settings: [String: Any]?
+    private var settings: [String: BuildFileSetting]?
     private var packageProduct: SwiftPackageProductDependencyData?
 
     @discardableResult
@@ -51,13 +51,13 @@ final class PBXBuildFileBuilder {
 
     @discardableResult
     func setSettings(_ settings: [String: [String]]) -> PBXBuildFileBuilder {
-        self.settings = settings
+        self.settings = settings.mapValues { .array($0) }
         return self
     }
 
     @discardableResult
     func setSettings(_ settings: [String: String]) -> PBXBuildFileBuilder {
-        self.settings = settings
+        self.settings = settings.mapValues { .string($0) }
         return self
     }
 


### PR DESCRIPTION
**Describe your changes**

- Updates to xcdiff for compatibility with https://github.com/tuist/XcodeProj/pull/903
- Build setting values are no longer type erased and instead can now either be a `String` or `[String]`
- This alleviates the need to casting values and throwing errors when dealing with build settings

**Test Plan**

- Verify CI passes


