### PR TITLE
Remove redundant ruby file

### DIFF
--- a/Scripts/stub.rb
+++ b/Scripts/stub.rb
@@ -1,1 +1,0 @@
-# Stub file to satisfy CodeQL Analysis (Ruby) check. 


### PR DESCRIPTION
The file was added to satisfy ruby code scanner. The ruby file scanner has been deactivated such that we can also remove the stub file.

Test Plan:
- Ensure all CI checks pass