### PR TITLE
Update to Xcode 26.2

### DIFF
--- a/.github/workflows/xcdiff.yaml
+++ b/.github/workflows/xcdiff.yaml
@@ -10,7 +10,7 @@ on:
     - cron: "0 20 * * *"
 
 env:
-  DEVELOPER_DIR: "/Applications/Xcode_16.2.app/Contents/Developer"
+  DEVELOPER_DIR: "/Applications/Xcode_26.2.app/Contents/Developer"
 
 # Limit GITHUB_TOKEN permissions to read-only for repo contents
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
@@ -20,7 +20,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: macOS-14
+    runs-on: macOS-26
     steps:
     - uses: actions/checkout@v4
     - uses: jdx/mise-action@v3
@@ -35,7 +35,7 @@ jobs:
 
   build:
     name: Build & Test
-    runs-on: macOS-14
+    runs-on: macOS-26
     steps:
     - uses: actions/checkout@v4
     - uses: actions/cache@v4


### PR DESCRIPTION
- Update the GitHub actions runner and Xcode versions

Test Plan:

- Verify CI passes
