### PR TITLE
Bumped xcodeproj version to support PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet

### DIFF
--- a/Fixtures/ios_project_malformed/Project.xcodeproj/project.pbxproj
+++ b/Fixtures/ios_project_malformed/Project.xcodeproj/project.pbxproj
@@ -1,0 +1,1 @@
+this is not valid pbxproj content

--- a/Fixtures/ios_project_malformed/Project.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Fixtures/ios_project_malformed/Project.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Project.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/tadija/AEXML.git",
         "state": {
           "branch": null,
-          "revision": "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
-          "version": "4.6.1"
+          "revision": "db806756c989760b35108146381535aec231092b",
+          "version": "4.7.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
           "branch": null,
-          "revision": "6f90427e172da66336739801c84b9cef3e17367b",
-          "version": "8.26.6"
+          "revision": "b1caa062d4aaab3e3d2bed5fe0ac5f8ce9bf84f4",
+          "version": "8.27.7"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.3.0"),
         .package(url: "https://github.com/kylef/PathKit", from: "1.0.0"),
-        .package(url: "https://github.com/tuist/xcodeproj.git", from: "8.26.6"),
+        .package(url: "https://github.com/tuist/xcodeproj.git", from: "8.27.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
     ],
     targets: [

--- a/Sources/XCDiffCore/Library/XcodeProjLoader.swift
+++ b/Sources/XCDiffCore/Library/XcodeProjLoader.swift
@@ -28,7 +28,9 @@ class DefaultXcodeProjLoader: XcodeProjLoader {
         } catch let error as XCodeProjError {
             throw ComparatorError.generic(error.description)
         } catch {
-            throw ComparatorError.generic("Encountered unknown error while loading XcodeProj at \(path.string)")
+            throw ComparatorError.generic(
+                "Encountered unknown error while loading XcodeProj at \(path.string). \(error)"
+            )
         }
     }
 }

--- a/Tests/XCDiffCoreTests/Helpers/Fixtures.swift
+++ b/Tests/XCDiffCoreTests/Helpers/Fixtures.swift
@@ -65,6 +65,10 @@ final class ProjectFixtures {
         return path(to: "non_existing")
     }
 
+    func ios_project_malformed() -> Path {
+        return path(to: "ios_project_malformed")
+    }
+
     func ios_project_1() -> Path {
         return path(to: "ios_project_1")
     }

--- a/Tests/XCDiffCoreTests/Library/XcodeProjLoaderTests.swift
+++ b/Tests/XCDiffCoreTests/Library/XcodeProjLoaderTests.swift
@@ -53,4 +53,21 @@ final class DefaultXcodeProjLoaderTests: XCTestCase {
             XCTAssertEqual(error.localizedDescription, "The project cannot be found at \(path.string)")
         }
     }
+
+    func testLoad_whenProjectIsMalformed() {
+        // Given
+        let path = fixtures.project.ios_project_malformed()
+
+        // When / Then
+        XCTAssertThrowsError(try subject.load(at: path)) { error in
+            guard let error = error as? ComparatorError else {
+                XCTFail("Expected ComparatorError")
+                return
+            }
+            XCTAssertTrue(error.localizedDescription.hasPrefix("Encountered unknown error while loading XcodeProj at"))
+            XCTAssertTrue(error.localizedDescription.contains(path.string))
+            // Verify the underlying error details are included (the change on this branch)
+            XCTAssertFalse(error.localizedDescription.hasSuffix(path.string))
+        }
+    }
 }


### PR DESCRIPTION
hey,

small PR to support the xcode projects with the `PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet`

**Describe your changes**
- Bumps the version of xcodeproj to include the fix https://github.com/tuist/XcodeProj/pull/894
- Adds a better error message in case of unsupported elements

**Testing performed**

**Additional context**

I the current master, I was getting the error 
```
xcdiff  -p1 Proj1.xcodeproj -p2 Proj2.xcodeproj -v
ERROR: Encountered unknown error while loading XcodeProj at Proj1.xcodeproj
```

I debugged in the sources a found out it's becase of an unspupported xcode element. 

I added a the error to the log message:
```
ERROR: Encountered unknown error while loading XcodeProj at Proj1.xcodeproj: The element PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet is not supported.
```
