### PR TITLE
Fix CustomStringConvertible warning

### DIFF
--- a/Sources/XCDiffCore/Library/PBX+Extensions.swift
+++ b/Sources/XCDiffCore/Library/PBX+Extensions.swift
@@ -17,7 +17,7 @@
 import Foundation
 import XcodeProj
 
-extension PBXCopyFilesBuildPhase.SubFolder: CustomStringConvertible {
+extension PBXCopyFilesBuildPhase.SubFolder: @retroactive CustomStringConvertible {
     public var description: String {
         switch self {
         case .absolutePath: return "absolutePath"
@@ -43,7 +43,7 @@ extension PBXTarget {
     }
 }
 
-extension XCRemoteSwiftPackageReference.VersionRequirement: CustomStringConvertible {
+extension XCRemoteSwiftPackageReference.VersionRequirement: @retroactive CustomStringConvertible {
     public var description: String {
         switch self {
         case let .upToNextMajorVersion(version):


### PR DESCRIPTION
The `@retroactive` attribute in Swift is a compiler directive used in extensions to explicitly acknowledge that a type is being conformed to a protocol when the developer owns neither. When applied to `CustomStringConvertible`, it instructs the compiler to accept our custom description implementation despite the "retroactive" conformance, which could conflict with future versions of the original module.

Currently, `CustomStringConvertible` is not implemented in XcodeProj. However, if an implementation is added there in the future, the resolution behavior (whether the XcodeProj or local xcdiff implementation is used) will be non-deterministic (as far as I understand). We will likely need to revisit our approach at that time.

Test Plan:
- Ensure all CI checks pass